### PR TITLE
Add global leaderboard and expanded stats

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,7 +43,7 @@ import type {
 import { CONFIG, PLAYER_COLORS, RARITY_SCORES } from "@/lib/constants"
 import { STATIC_DATA } from "@/lib/game-data"
 import { auth, db } from "@/lib/firebase"
-import { doc, getDoc, setDoc } from "firebase/firestore"
+import { collection, doc, getDoc, getDocs, setDoc } from "firebase/firestore"
 import { signInAnonymously } from "firebase/auth"
 
 import { initialVentures as empireInitialVentures } from "@/components/empire-tab"
@@ -336,6 +336,35 @@ const calculateEquipmentScore = (equipment: GameState["equipment"]): number => {
   return score
 }
 
+// Fetch leaderboard data for all players from Firestore
+const fetchLeaderboardData = async (): Promise<RankedPlayer[]> => {
+  const snapshot = await getDocs(collection(db, "players"))
+  const players: RankedPlayer[] = []
+  snapshot.forEach((docSnap) => {
+    const data = docSnap.data() as GameState
+    if (!data?.player) return
+    const equipmentScore = calculateEquipmentScore(data.equipment)
+    const power =
+      data.resources.solari * 0.01 +
+      data.player.territories.length * 50 +
+      equipmentScore * 100 +
+      data.player.totalEnemiesDefeated * 5
+    const rank = Math.max(1, 100 - Math.floor(power / 100))
+    const rankName = rank < 10 ? "Spice Baron" : rank < 50 ? "Guild Associate" : "Sand Nomad"
+    players.push({
+      id: data.player.id || docSnap.id,
+      name: data.player.name,
+      rank,
+      rankName,
+      house: data.player.house,
+      prestigeLevel: data.player.prestigeLevel,
+      color: data.player.color,
+      power,
+    })
+  })
+  return players.sort((a, b) => b.power - a.power)
+}
+
 // --- CONFIGURATION FOR NEW SYSTEMS ---
 const AI_CONFIG = {
   PROCESSING_INTERVAL: 10000, // AI acts every 10 seconds
@@ -512,6 +541,21 @@ export default function ArrakisGamePage() {
       }
     }
     initGame()
+  }, [])
+
+  // Periodically refresh leaderboard from Firestore
+  useEffect(() => {
+    const updateLeaderboard = async () => {
+      try {
+        const leaderboard = await fetchLeaderboardData()
+        setGameState((prev) => ({ ...prev, leaderboard }))
+      } catch (err) {
+        console.error("Failed to fetch leaderboard", err)
+      }
+    }
+    updateLeaderboard()
+    const interval = setInterval(updateLeaderboard, 30000)
+    return () => clearInterval(interval)
   }, [])
 
   const handleSendMessage = useCallback((message: string) => {

--- a/components/player-stats-panel.tsx
+++ b/components/player-stats-panel.tsx
@@ -59,6 +59,24 @@ export function PlayerStatsPanel({ player }: PlayerStatsPanelProps) {
             <span className="font-mono text-purple-400 font-bold prestige-glow">{player.prestigeLevel}</span>
           </div>
         </div>
+        <div className="p-2 bg-stone-600 rounded">
+          <div className="flex justify-between mb-1">
+            <span>Territories:</span>
+            <span className="font-mono">{player.territories.length}</span>
+          </div>
+        </div>
+        <div className="p-2 bg-stone-600 rounded">
+          <div className="flex justify-between mb-1">
+            <span>Enemies Defeated:</span>
+            <span className="font-mono">{player.totalEnemiesDefeated}</span>
+          </div>
+        </div>
+        <div className="p-2 bg-stone-600 rounded">
+          <div className="flex justify-between mb-1">
+            <span>Lifetime Spice:</span>
+            <span className="font-mono">{player.lifetimeSpice}</span>
+          </div>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- query Firestore for player rankings and update leaderboard periodically
- show more detailed player stats like territories owned, enemies defeated and lifetime spice

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c583450832f8156a54d8c4505aa