### PR TITLE
Improve mobile layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -83,6 +83,17 @@ body {
   color: #fed7aa; /* Default text color for desert cells */
 }
 
+@media (max-width: 640px) {
+  .map-grid {
+    grid-template-columns: repeat(15, 20px);
+  }
+  .map-cell {
+    width: 20px;
+    height: 20px;
+    font-size: 0.75rem;
+  }
+}
+
 .map-cell:hover {
   transform: scale(1.1);
   z-index: 10;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} ${orbitron.variable} bg-stone-950 text-stone-300 antialiased`}>
+      <body
+        className={`${inter.variable} ${orbitron.variable} bg-stone-950 text-stone-300 antialiased overflow-x-hidden`}
+      >
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- shrink map grid and cells on small screens for a better mobile view
- hide horizontal overflow in layout body

## Testing
- `npm install --legacy-peer-deps`
- `npm run build` *(fails: Failed to fetch Google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b3ea410832fb02044787c61ec98