### PR TITLE
Improve combat scaling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -622,3 +622,13 @@ body {
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {
   background: #71717a;
 }
+@media (max-width: 480px) {
+  .combat-modal-content {
+    width: 95%;
+    padding: 15px;
+  }
+  .action-button {
+    flex: 1;
+    font-size: 0.875rem;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1575,8 +1575,15 @@ export default function ArrakisGamePage() {
           else targetEnemyLevel = Math.max(1, player.level - getRandomInt(0, 1))
 
           const levelDifference = targetEnemyLevel - originalEnemyData.level
-          // Ensure scalingMultiplier is always positive
-          const scalingMultiplier = Math.max(0.1, 1 + levelDifference * CONFIG.ENEMY_SCALING_FACTOR)
+          // Ensure scalingMultiplier is always positive and adjust by player gear
+          const gearPower =
+            (player.equipment?.weapon?.attack || 0) +
+            (player.equipment?.armor?.defense || 0) +
+            (player.equipment?.accessory?.attack || 0) +
+            (player.equipment?.accessory?.defense || 0)
+          const gearMultiplier = 1 + gearPower * CONFIG.GEAR_SCALING_FACTOR
+          const scalingMultiplier =
+            Math.max(0.1, 1 + levelDifference * CONFIG.ENEMY_SCALING_FACTOR) * gearMultiplier
 
           const scaledEnemy: Enemy = {
             ...enemyOnCell,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -20,6 +20,7 @@ export const CONFIG = {
   COMBAT_TURN_DELAY: 1500, // Delay between turns in combat (ms) - This is now just a visual delay for enemy action
   // Removed COMBAT_MINIGAME_DURATION, COMBAT_TURN_DURATION
   ENEMY_SCALING_FACTOR: 0.1, // 10% stat increase per level difference
+  GEAR_SCALING_FACTOR: 0.01, // Additional scaling per gear power point
   FLEE_CHANCE: 0.6, // 60% chance to flee successfully
   SPICE_SELL_COST: 50, // Spice required to sell
   SPICE_SELL_YIELD: 50, // Solari gained from selling spice


### PR DESCRIPTION
## Summary
- scale enemy stats based on player equipment
- tweak combat modal styles for mobile
- add gear scaling constant

## Testing
- `npm run lint` *(fails: prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_683f56c229a0832f8b1beea53b5cf578