### PR TITLE
Improve mobile friendliness

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -55,8 +55,10 @@ body {
 }
 
 .map-grid {
+  --map-columns: 15;
+  --cell-size: 32px;
   display: grid;
-  grid-template-columns: repeat(15, 32px);
+  grid-template-columns: repeat(var(--map-columns), var(--cell-size));
   gap: 1px;
   background: linear-gradient(45deg, #451a03, #1c1917);
   border: 2px solid #f59e0b;
@@ -64,11 +66,20 @@ body {
   padding: 8px;
   margin: 0 auto;
   box-shadow: 0 0 20px rgba(245, 158, 11, 0.3);
+  width: max-content;
+  overflow-x: auto;
+}
+
+@media (max-width: 640px) {
+  .map-grid {
+    --map-columns: 10;
+    --cell-size: 28px;
+  }
 }
 
 .map-cell {
-  width: 32px;
-  height: 32px;
+  width: var(--cell-size);
+  height: var(--cell-size);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -518,6 +529,14 @@ body {
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+@media (max-width: 640px) {
+  .combat-modal-content {
+    padding: 16px;
+    width: 100%;
+    max-width: none;
+  }
 }
 
 .combat-log {

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -116,5 +116,5 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
     }
   }
 
-  return <div className="map-grid mx-auto">{cells}</div>
+  return <div className="map-grid mx-auto overflow-x-auto">{cells}</div>
 }

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -15,8 +15,8 @@ const tabs = [
 
 export function Navigation({ currentTab, onTabChange }: NavigationProps) {
   return (
-    <nav className="bg-stone-800 border-b border-stone-600 px-6 fixed top-[88px] left-0 right-0 z-100">
-      <div className="flex space-x-2">
+    <nav className="bg-stone-800 border-b border-stone-600 px-6 fixed top-[88px] left-0 right-0 z-100 overflow-x-auto">
+      <div className="flex space-x-2 whitespace-nowrap">
         {tabs.map((tab) => (
           <button
             key={tab.id}


### PR DESCRIPTION
## Summary
- make navigation scrollable on small screens
- allow MapGrid to scroll horizontally and scale on small devices
- adjust map cells size with CSS variables
- tweak combat modal padding for mobile

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5689d974832fafdfd6d21459a5c0