### PR TITLE
Allow territory colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,14 @@
 :root {
   --font-inter: "Inter", sans-serif;
   --font-orbitron: "Orbitron", sans-serif;
+  --player-color-red: #ef4444;
+  --player-color-blue: #3b82f6;
+  --player-color-green: #10b981;
+  --player-color-purple: #8b5cf6;
+  --player-color-orange: #f97316;
+  --player-color-pink: #ec4899;
+  --player-color-yellow: #eab308;
+  --player-color-cyan: #06b6d4;
 }
 
 body {
@@ -426,10 +434,6 @@ body {
   background: rgba(28, 25, 23, 0.8);
 }
 
-.territory-owned {
-  background: radial-gradient(circle, rgba(16, 185, 129, 0.3), rgba(16, 185, 129, 0.1)) !important;
-  border: 2px dashed #10b981 !important;
-}
 
 .world-event-marker {
   position: absolute;

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -50,10 +50,9 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
       if (territory) {
         cellClass += " map-cell-territory"
         if (territory.ownerId === player.id) {
-          cellClass += " territory-owned"
           cellTitle = `Your Territory: ${territory.name || key}`
         } else if (territory.ownerId) {
-          cellClass += ` player-color-${territory.ownerColor || "gray"}` // Border color based on owner
+          cellClass += ` player-color-${territory.ownerColor || "gray"}`
           cellTitle = `Territory of ${territory.ownerName || "Unknown"} (${key})`
         } else {
           cellTitle = `Unclaimed Territory (${key}) - Cost: ${territory.purchaseCost}`
@@ -105,8 +104,11 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
           title={cellTitle}
           onClick={() => onCellClick(x, y)}
           style={
-            territory && territory.ownerId && territory.ownerId !== player.id
-              ? { borderColor: `var(--player-color-${territory.ownerColor || "gray"})` }
+            territory && territory.ownerId
+              ? {
+                  borderColor: `var(--player-color-${territory.ownerColor || "gray"})`,
+                  backgroundColor: `var(--player-color-${territory.ownerColor || "gray"})`,
+                }
               : {}
           }
         >


### PR DESCRIPTION
## Summary
- add player color CSS variables
- color map tiles of owned territories

## Testing
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_683f7f157074832f92d9d5975965f6bd