### PR TITLE
Implement territory capture system

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -35,6 +35,7 @@ export const CONFIG = {
   NEW_WORLD_EVENT_CHANCE_PER_TICK: 0.002, // 0.2% chance per second to trigger a new world event
   WORLD_EVENT_ENERGY_DRAIN_RATE: 1, // Energy drained per tick by relevant world events
   ENEMY_TARGET_SCAN_RANGE: 7, // Range for enemies to "see" player for targeting
+  TERRITORY_CAPTURE_THRESHOLD: 3, // Number of failed attempts before territory becomes purchasable
 }
 
 export const PLAYER_COLORS = ["red", "blue", "green", "purple", "orange", "pink", "yellow", "cyan"]

--- a/types/game.ts
+++ b/types/game.ts
@@ -123,6 +123,8 @@ export interface TerritoryDetails extends MapElement {
   // NEW: For Sandworm destruction
   isDestroyed?: boolean
   destroyedUntil?: number
+  // NEW: Track how weakened a territory is when players fail to capture it
+  captureLevel?: number
 }
 
 export interface Investment {
@@ -234,6 +236,8 @@ export interface GameState {
   // NEW: Track last time AI and World Events were processed
   lastAIProcessingTime?: number
   lastWorldEventProcessingTime?: number
+  // NEW: Track which territory is being contested in combat
+  capturingTerritoryId?: string | null
 }
 
 export type PlayerColor = "red" | "blue" | "green" | "purple" | "orange" | "pink" | "yellow" | "cyan"


### PR DESCRIPTION
## Summary
- introduce `captureLevel` to territories and add `capturingTerritoryId` game state
- configure new `TERRITORY_CAPTURE_THRESHOLD`
- enable battling territory owners when entering an owned sector
- update combat end to transfer or weaken territory
- reset capture progress when buying or AI claiming land

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: numerous missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683f806b1548832fb1229a592a1f9ad5