### PR TITLE
Restrict prestige ability to level 20

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1963,8 +1963,14 @@ export default function ArrakisGamePage() {
   }, [addNotification])
 
   const handleOpenPrestigeModal = useCallback(() => {
-    setGameState((prev) => ({ ...prev, isPrestigeModalOpen: true }))
-  }, [])
+    setGameState((prev) => {
+      if (prev.player.level < 20) {
+        addNotification("Reach level 20 to Prestige!", "warning")
+        return prev
+      }
+      return { ...prev, isPrestigeModalOpen: true }
+    })
+  }, [addNotification])
 
   const handleClosePrestigeModal = useCallback(() => {
     setGameState((prev) => ({ ...prev, isPrestigeModalOpen: false }))

--- a/components/character-tab.tsx
+++ b/components/character-tab.tsx
@@ -134,10 +134,17 @@ export function CharacterTab({
               Reach new heights of power by prestiging! Reset your progress for a significant bonus to future gains.
             </p>
             <button
-              onClick={onOpenPrestigeModal}
-              className="w-full py-2 px-4 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-md transition duration-150 ease-in-out"
+              onClick={player.level >= 20 ? onOpenPrestigeModal : undefined}
+              disabled={player.level < 20}
+              className={`w-full py-2 px-4 font-semibold rounded-md transition duration-150 ease-in-out ${
+                player.level >= 20
+                  ? "bg-purple-600 hover:bg-purple-700 text-white"
+                  : "bg-stone-500 text-white cursor-not-allowed"
+              }`}
             >
-              Ascend to Prestige {player.prestigeLevel + 1}
+              {player.level >= 20
+                ? `Ascend to Prestige ${player.prestigeLevel + 1}`
+                : "Reach Level 20 to Prestige"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- disable prestige button until player reaches level 20
- show notice when trying to prestige early

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683f7ee6d2c8832fa71b87ec63793342