### PR TITLE
Fix territory purchase bug

### DIFF
--- a/components/modals/territory-modal.tsx
+++ b/components/modals/territory-modal.tsx
@@ -50,7 +50,12 @@ export function TerritoryModal({ isOpen, onClose, territory, playerResources, on
                 ))}
             </ul>
             <button
-              onClick={() => onPurchase(territory.id, territory.purchaseCost)}
+              onClick={() =>
+                onPurchase(
+                  `${territory.x},${territory.y}`,
+                  territory.purchaseCost,
+                )
+              }
               disabled={!canAfford}
               className="w-full py-3 bg-amber-600 hover:bg-amber-700 rounded font-bold text-lg disabled:bg-stone-500 disabled:cursor-not-allowed"
             >


### PR DESCRIPTION
## Summary
- fix purchasing unowned territory by passing the correct coordinates to `onPurchase`

## Testing
- `pnpm install`
- `npm run lint` *(fails: prompts for manual configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683f829f1a60832f9e608e5920182fa5