### PR TITLE
Improve enemy scaling for challenge

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1663,9 +1663,9 @@ export default function ArrakisGamePage() {
           // ... (combat initiation logic from original, ensure it uses scaledEnemy correctly)
           const originalEnemyData = STATIC_DATA.ENEMIES[enemyOnCell.type as keyof typeof STATIC_DATA.ENEMIES]
           let targetEnemyLevel = player.level
-          if (originalEnemyData.boss) targetEnemyLevel = Math.max(1, player.level + getRandomInt(0, 2))
-          else if (originalEnemyData.special) targetEnemyLevel = Math.max(1, player.level + getRandomInt(0, 1))
-          else targetEnemyLevel = Math.max(1, player.level - getRandomInt(0, 1))
+          if (originalEnemyData.boss) targetEnemyLevel = Math.max(1, player.level + getRandomInt(1, 3))
+          else if (originalEnemyData.special) targetEnemyLevel = Math.max(1, player.level + getRandomInt(1, 2))
+          else targetEnemyLevel = Math.max(1, player.level + getRandomInt(-1, 1))
 
           const levelDifference = targetEnemyLevel - originalEnemyData.level
           // Ensure scalingMultiplier is always positive and adjust by player gear
@@ -1675,8 +1675,9 @@ export default function ArrakisGamePage() {
             (player.equipment?.accessory?.attack || 0) +
             (player.equipment?.accessory?.defense || 0)
           const gearMultiplier = 1 + gearPower * CONFIG.GEAR_SCALING_FACTOR
-          const scalingMultiplier =
-            Math.max(0.1, 1 + levelDifference * CONFIG.ENEMY_SCALING_FACTOR) * gearMultiplier
+          const baseScaling = Math.max(0.1, 1 + levelDifference * CONFIG.ENEMY_SCALING_FACTOR)
+          const specialBonus = originalEnemyData.special ? 1 + CONFIG.SPECIAL_ENEMY_SCALING_BONUS : 1
+          const scalingMultiplier = baseScaling * gearMultiplier * specialBonus
 
           const scaledEnemy: Enemy = {
             ...enemyOnCell,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -19,8 +19,9 @@ export const CONFIG = {
   ITEM_RESPAWN_COOLDOWN: 60000, // 1 minute for items to respawn
   COMBAT_TURN_DELAY: 1500, // Delay between turns in combat (ms) - This is now just a visual delay for enemy action
   // Removed COMBAT_MINIGAME_DURATION, COMBAT_TURN_DURATION
-  ENEMY_SCALING_FACTOR: 0.1, // 10% stat increase per level difference
+  ENEMY_SCALING_FACTOR: 0.15, // 15% stat increase per level difference
   GEAR_SCALING_FACTOR: 0.01, // Additional scaling per gear power point
+  SPECIAL_ENEMY_SCALING_BONUS: 0.25, // Extra scaling for special enemies
   FLEE_CHANCE: 0.6, // 60% chance to flee successfully
   SPICE_SELL_COST: 50, // Spice required to sell
   SPICE_SELL_YIELD: 50, // Solari gained from selling spice


### PR DESCRIPTION
## Summary
- tune global constants to make enemies tougher
- boost special enemy scaling
- scale enemy level selection to better match player level

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8492aa78832fb1eb776fe94aadac