### PR TITLE
Add item stat tooltips

### DIFF
--- a/components/character-tab.tsx
+++ b/components/character-tab.tsx
@@ -37,6 +37,14 @@ export function CharacterTab({
     { label: "XP Gain Bonus", value: `${totalXPGainBonus.toFixed(1)}%`, color: "text-purple-400" },
   ]
 
+  const getItemTooltip = (item: Item) => {
+    const lines = [item.name, item.description]
+    if (item.attack) lines.push(`Attack: +${item.attack}`)
+    if (item.defense) lines.push(`Defense: +${item.defense}`)
+    if (item.special) lines.push(`Special: ${item.special}`)
+    return lines.join("\n")
+  }
+
   const getCooldownRemaining = (abilityId: string) => {
     const cooldownEnd = abilityCooldowns[abilityId]
     if (!cooldownEnd) return 0
@@ -52,14 +60,20 @@ export function CharacterTab({
         <div className="bg-stone-800 p-6 rounded-lg border border-stone-600">
           <h3 className="text-xl font-semibold mb-4 text-amber-300">Equipment</h3>
           <div className="grid grid-cols-3 gap-4 text-center mb-6">
-            {(Object.keys(equipment) as Array<keyof Equipment>).map((slot) => (
-              <div key={slot}>
-                <div title={equipment[slot]?.name || "Empty"} className="inventory-slot mx-auto mb-2 w-16 h-16">
-                  {equipment[slot]?.icon || ""}
+            {(Object.keys(equipment) as Array<keyof Equipment>).map((slot) => {
+              const eqItem = equipment[slot]
+              return (
+                <div key={slot}>
+                  <div
+                    title={eqItem ? getItemTooltip(eqItem) : "Empty"}
+                    className="inventory-slot mx-auto mb-2 w-16 h-16"
+                  >
+                    {eqItem?.icon || ""}
+                  </div>
+                  <span className="text-sm font-semibold capitalize">{slot}</span>
                 </div>
-                <span className="text-sm font-semibold capitalize">{slot}</span>
-              </div>
-            ))}
+              )
+            })}
           </div>
 
           <h3 className="text-xl font-semibold mb-4 text-amber-300">
@@ -69,7 +83,7 @@ export function CharacterTab({
             {inventory.map((item, index) => (
               <div
                 key={index}
-                title={item ? `${item.name}\n${item.description}` : "Empty Slot"}
+                title={item ? getItemTooltip(item) : "Empty Slot"}
                 className={`inventory-slot ${item ? "cursor-pointer hover:border-amber-500" : "opacity-50"}`}
                 onClick={() => item && onEquipItem(item, index)}
               >


### PR DESCRIPTION
## Summary
- show item stats in character tab tooltips

## Testing
- `pnpm install`
- `npm run lint` *(fails: prompts about ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683f84b89fb8832fa5a54d512fefa513