### PR TITLE
Add territory capture after enemy defeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Recent additions to **Arrakis Spice Empire** include:
 - Expanded prestige system with XP bonuses.
 - Multiplayer hub featuring world chat, trading, and a territory chart.
 - Improved leaderboard tracking player ranks and power.
+- Defeating an enemy now grants your house control of the surrounding sectors.
 
 ## How It Works
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -639,7 +639,11 @@ export default function ArrakisGamePage() {
       const currentFullGameState = gameStateRef.current // Use ref for up-to-date inventory etc.
       const newPlayer = { ...playerState }
       const newResources = { ...resourcesState }
-      const newMap = { ...mapState, enemies: { ...mapState.enemies } } // Be careful with deep copies if needed
+      const newMap = {
+        ...mapState,
+        enemies: { ...mapState.enemies },
+        territories: { ...mapState.territories },
+      } // Be careful with deep copies if needed
       const updatedInventory = [...currentFullGameState.inventory] // Use inventory from the ref
 
       if (result === "win") {
@@ -721,6 +725,42 @@ export default function ArrakisGamePage() {
             addNotification(`You captured ${terr.name || terrKey}!`, "success")
           }
         }
+
+        // Claim surrounding sectors for the player's house
+        const directions = [-1, 0, 1]
+        directions.forEach((dx) => {
+          directions.forEach((dy) => {
+            if (dx === 0 && dy === 0) return
+            const tx = enemyInstance.position.x + dx
+            const ty = enemyInstance.position.y + dy
+            if (tx < 0 || tx >= CONFIG.MAP_SIZE || ty < 0 || ty >= CONFIG.MAP_SIZE) return
+            const tKey = `${tx},${ty}`
+            const terr = newMap.territories[tKey]
+            if (terr) {
+              const prevOwner = terr.ownerId
+              newMap.territories[tKey] = {
+                ...terr,
+                ownerId: newPlayer.id,
+                ownerName: newPlayer.name,
+                ownerColor: newPlayer.color,
+                captureLevel: 0,
+              }
+              if (!newPlayer.territories.find((t) => t.id === terr.id)) {
+                newPlayer.territories.push(newMap.territories[tKey])
+              }
+              if (
+                prevOwner &&
+                prevOwner !== newPlayer.id &&
+                currentFullGameState.onlinePlayers[prevOwner]
+              ) {
+                currentFullGameState.onlinePlayers[prevOwner].territories = currentFullGameState.onlinePlayers[prevOwner].territories.filter(
+                  (t) => t.id !== terr.id,
+                )
+              }
+            }
+          })
+        })
+        addNotification("Your house seizes the surrounding territory!", "success")
       } else if (result === "lose") {
         newPlayer.position = { ...newPlayer.basePosition }
         newPlayer.health = Math.floor(newPlayer.maxHealth / 2)


### PR DESCRIPTION
## Summary
- gain control of the eight sectors around a defeated enemy
- copy territories when ending combat to prevent mutations
- document the new territory mechanic

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_683f85175704832fb2bdd35a67263396