### PR TITLE
Implement Great Sandstorm event

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1319,6 +1319,43 @@ export default function ArrakisGamePage() {
               }
               newWorldEvents.push(newEvent)
               addNotification(`New Event: ${newEvent.name}! - ${newEvent.description}`, "warning")
+
+              if (newEvent.effect === "territory_loss" && newEvent.effectValue) {
+                const ownedKeys = Object.keys(newMap.territories).filter(
+                  (tKey) => newMap.territories[tKey].ownerId,
+                )
+                const removeCount = Math.max(
+                  1,
+                  Math.floor(ownedKeys.length * newEvent.effectValue),
+                )
+                for (let i = 0; i < removeCount && ownedKeys.length > 0; i++) {
+                  const idx = getRandomInt(0, ownedKeys.length - 1)
+                  const terrKey = ownedKeys.splice(idx, 1)[0]
+                  const terr = newMap.territories[terrKey]
+                  const ownerId = terr.ownerId
+                  if (ownerId) {
+                    if (ownerId === newPlayer.id) {
+                      newPlayer.territories = newPlayer.territories.filter(
+                        (t) => t.id !== terr.id,
+                      )
+                      addNotification(
+                        `Sandstorm reclaimed ${terr.name || terrKey}!`,
+                        "warning",
+                      )
+                    } else if (newOnlinePlayers[ownerId]) {
+                      newOnlinePlayers[ownerId].territories = newOnlinePlayers[ownerId].territories.filter(
+                        (t) => t.id !== terr.id,
+                      )
+                    }
+                    newMap.territories[terrKey] = {
+                      ...terr,
+                      ownerId: null,
+                      ownerName: undefined,
+                      ownerColor: undefined,
+                    }
+                  }
+                }
+              }
               if (newEvent.rewards) {
                 // Apply immediate rewards
                 if (newEvent.rewards.spice) newResources.spice += newEvent.rewards.spice

--- a/lib/game-data.ts
+++ b/lib/game-data.ts
@@ -342,6 +342,16 @@ export const STATIC_DATA = {
       duration: 300000,
       type: "economy",
     },
+    {
+      name: "Great Sandstorm",
+      description:
+        "Blinding sandstorms ravage Arrakis, stripping control from many territories!",
+      icon: "🌬️",
+      effect: "territory_loss",
+      effectValue: 0.1, // 10% of all owned territories become neutral
+      duration: 180000,
+      type: "hazard",
+    },
   ],
   WORLD_EVENT_CONFIG: {
     maxActiveEvents: 3, // Max number of non-chained world events active at once


### PR DESCRIPTION
## Summary
- expand world events with a new `Great Sandstorm`
- remove territory ownership when the sandstorm event triggers

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_683f86cd8d70832f9a894995093b8908