### PR TITLE
Fix territory colors based on house ownership

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,7 +41,7 @@ import type {
   AIPlayer, // Added AIPlayer
   PlayerColor,
 } from "@/types/game"
-import { CONFIG, PLAYER_COLORS, RARITY_SCORES } from "@/lib/constants"
+import { CONFIG, PLAYER_COLORS, RARITY_SCORES, HOUSE_COLORS } from "@/lib/constants"
 import { STATIC_DATA } from "@/lib/game-data"
 import { auth, db } from "@/lib/firebase"
 import { collection, doc, getDoc, getDocs, setDoc } from "firebase/firestore"
@@ -453,7 +453,10 @@ export default function ArrakisGamePage() {
                     ...newMapTerritories[key],
                     ownerId: aiPlayer.id,
                     ownerName: aiPlayer.name,
-                    ownerColor: aiPlayer.color,
+                    ownerColor:
+                      HOUSE_COLORS[
+                        aiPlayer.house as keyof typeof HOUSE_COLORS
+                      ] || aiPlayer.color,
                   }
                 }
               })
@@ -523,7 +526,9 @@ export default function ArrakisGamePage() {
                   ...terrToClaim,
                   ownerId: ai.id,
                   ownerName: ai.name,
-                  ownerColor: ai.color,
+                  ownerColor:
+                    HOUSE_COLORS[ai.house as keyof typeof HOUSE_COLORS] ||
+                    ai.color,
                 }
                 ai.territories.push(newGameState.map.territories[key])
               }
@@ -709,7 +714,9 @@ export default function ArrakisGamePage() {
               ...terr,
               ownerId: newPlayer.id,
               ownerName: newPlayer.name,
-              ownerColor: newPlayer.color,
+              ownerColor:
+                HOUSE_COLORS[newPlayer.house as keyof typeof HOUSE_COLORS] ||
+                newPlayer.color,
               captureLevel: 0,
             }
             newPlayer.territories = [...newPlayer.territories, newMap.territories[terrKey]]
@@ -972,7 +979,9 @@ export default function ArrakisGamePage() {
             ...newMapTerritories[key],
             ownerId: newPlayer.id,
             ownerName: newPlayer.name,
-            ownerColor: newPlayer.color,
+            ownerColor:
+              HOUSE_COLORS[newPlayer.house as keyof typeof HOUSE_COLORS] ||
+              newPlayer.color,
           }
         }
       })
@@ -984,9 +993,16 @@ export default function ArrakisGamePage() {
           // Give AIs new random territories
           const unownedTerritories = Object.values(newMapTerritories).filter((t) => !t.ownerId)
           if (unownedTerritories.length > 0) {
-            const terrToClaim = unownedTerritories[getRandomInt(0, unownedTerritories.length - 1)]
+            const terrToClaim =
+              unownedTerritories[getRandomInt(0, unownedTerritories.length - 1)]
             const key = `${terrToClaim.position.x},${terrToClaim.position.y}`
-            newMapTerritories[key] = { ...terrToClaim, ownerId: ai.id, ownerName: ai.name, ownerColor: ai.color }
+            newMapTerritories[key] = {
+              ...terrToClaim,
+              ownerId: ai.id,
+              ownerName: ai.name,
+              ownerColor:
+                HOUSE_COLORS[ai.house as keyof typeof HOUSE_COLORS] || ai.color,
+            }
             ai.territories.push(newMapTerritories[key])
           }
         }
@@ -1401,7 +1417,9 @@ export default function ArrakisGamePage() {
                     ...targetTerritory,
                     ownerId: ai.id,
                     ownerName: ai.name,
-                    ownerColor: ai.color,
+                    ownerColor:
+                      HOUSE_COLORS[ai.house as keyof typeof HOUSE_COLORS] ||
+                      ai.color,
                     captureLevel: 0,
                   }
                   ai.territories.push(newMap.territories[key]) // Add to AI's list
@@ -1902,7 +1920,9 @@ export default function ArrakisGamePage() {
           ...territory,
           ownerId: newPlayer.id,
           ownerName: newPlayer.name,
-          ownerColor: newPlayer.color,
+          ownerColor:
+            HOUSE_COLORS[newPlayer.house as keyof typeof HOUSE_COLORS] ||
+            newPlayer.color,
           captureLevel: 0,
         }
         newMap.territories[territoryId] = updatedTerritory

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,5 @@
+import type { PlayerColor } from "@/types/game"
+
 export const CONFIG = {
   MAP_SIZE: 200,
   VIEW_RADIUS: 7,
@@ -38,7 +40,22 @@ export const CONFIG = {
   TERRITORY_CAPTURE_THRESHOLD: 3, // Number of failed attempts before territory becomes purchasable
 }
 
-export const PLAYER_COLORS = ["red", "blue", "green", "purple", "orange", "pink", "yellow", "cyan"]
+export const PLAYER_COLORS = [
+  "red",
+  "blue",
+  "green",
+  "purple",
+  "orange",
+  "pink",
+  "yellow",
+  "cyan",
+]
+
+export const HOUSE_COLORS: Record<string, PlayerColor> = {
+  atreides: "blue",
+  harkonnen: "red",
+  fremen: "green",
+}
 
 export const DUNE_QUOTES = [
   "Fear is the mind-killer.",


### PR DESCRIPTION
## Summary
- add `HOUSE_COLORS` mapping
- color territories using the owning house color

## Testing
- `pnpm install`
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_683f84526fd8832fa9e7b9f5b380018c