### PR TITLE
Show names on grid

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -136,6 +136,18 @@ body {
   border: 2px solid currentColor !important;
 }
 
+.player-name-label {
+  position: absolute;
+  top: -0.8em;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: calc(var(--cell-size) * 0.25);
+  line-height: 1;
+  white-space: nowrap;
+  text-shadow: 0 0 2px #000;
+  pointer-events: none;
+}
+
 .map-cell-enemy {
   background: linear-gradient(135deg, #ef4444, #dc2626) !important;
   color: white !important;

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -27,12 +27,14 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
       let cellClass = "map-cell map-cell-desert" // Default to desert
       let cellContent = "" // Default desert cells will be styled by map-cell-desert
       let cellTitle = `Desert (${x},${y})`
+      let playerLabel: string | null = null
 
       // Player
       if (x === playerX && y === playerY) {
         cellClass += " map-cell-player"
         cellContent = "👤"
         cellTitle = `${player.name} (P${player.prestigeLevel}) - Your Position`
+        playerLabel = player.name
       }
       // Other players
       else {
@@ -43,6 +45,7 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
           cellClass += ` map-cell-other-player player-color-${otherPlayerOnCell.color || "gray"}`
           cellContent = "👤"
           cellTitle = `${otherPlayerOnCell.name} (P${otherPlayerOnCell.prestigeLevel || 0})`
+          playerLabel = otherPlayerOnCell.name
         }
       }
 
@@ -113,6 +116,7 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
               : {}
           }
         >
+          {playerLabel && <span className="player-name-label">{playerLabel}</span>}
           {cellContent}
         </div>,
       )


### PR DESCRIPTION
## Summary
- display player names above icons in the map grid
- style new player label elements

## Testing
- `npx next lint` *(fails: `npm error canceled`)*

------
https://chatgpt.com/codex/tasks/task_e_683f8750b9ec832fb197c5a68739664c