### PR TITLE
Fix undefined territories error

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -363,10 +363,10 @@ const fetchLeaderboardData = async (): Promise<RankedPlayer[]> => {
     if (!data?.player) return
     const equipmentScore = calculateEquipmentScore(data.equipment)
     const score = calculatePlayerScore(
-      data.player.territories.length,
-      data.resources.solari,
+      data.player.territories?.length ?? 0,
+      data.resources?.solari ?? 0,
       equipmentScore,
-      data.player.totalEnemiesDefeated,
+      data.player.totalEnemiesDefeated ?? 0,
     )
     players.push({
       id: data.player.id || docSnap.id,

--- a/components/houses-panel.tsx
+++ b/components/houses-panel.tsx
@@ -5,11 +5,11 @@ import type { GameState, TerritoryDetails, Player } from "@/types/game"
 
 interface HousesPanelProps {
   onlinePlayers: GameState["onlinePlayers"]
-  territories: Record<string, TerritoryDetails>
+  territories?: Record<string, TerritoryDetails>
   player: Pick<Player, "id" | "house">
 }
 
-export function HousesPanel({ onlinePlayers, territories, player }: HousesPanelProps) {
+export function HousesPanel({ onlinePlayers, territories = {}, player }: HousesPanelProps) {
   // Calculate player distribution per house
   const houseCounts: Record<string, number> = {}
   let totalPlayersWithHouse = 0

--- a/components/territory-chart.tsx
+++ b/components/territory-chart.tsx
@@ -7,7 +7,7 @@ import type { TerritoryDetails, GameState } from "@/types/game"
 import { STATIC_DATA } from "@/lib/game-data"
 
 interface TerritoryChartProps {
-  territories: Record<string, TerritoryDetails>
+  territories?: Record<string, TerritoryDetails>
   onlinePlayers: GameState["onlinePlayers"]
 }
 
@@ -18,7 +18,7 @@ const COLORS = {
   unclaimed: "#6b7280", // gray-500
 }
 
-export function TerritoryChart({ territories, onlinePlayers }: TerritoryChartProps) {
+export function TerritoryChart({ territories = {}, onlinePlayers }: TerritoryChartProps) {
   const territoryData: { name: string; value: number; color: string }[] = []
   const houseTerritoryCounts: Record<string, number> = {
     atreides: 0,


### PR DESCRIPTION
## Summary
- guard against missing territory data when building leaderboard
- allow HousesPanel and TerritoryChart to accept undefined territories

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8a843580832fb37dcd6be301b1bb