### PR TITLE
Adjust enemy scaling

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -21,8 +21,9 @@ export const CONFIG = {
   ITEM_RESPAWN_COOLDOWN: 60000, // 1 minute for items to respawn
   COMBAT_TURN_DELAY: 1500, // Delay between turns in combat (ms) - This is now just a visual delay for enemy action
   // Removed COMBAT_MINIGAME_DURATION, COMBAT_TURN_DURATION
-  ENEMY_SCALING_FACTOR: 0.15, // 15% stat increase per level difference
-  GEAR_SCALING_FACTOR: 0.01, // Additional scaling per gear power point
+  // Slightly higher scaling so enemies keep up with player progression
+  ENEMY_SCALING_FACTOR: 0.2, // 20% stat increase per level difference
+  GEAR_SCALING_FACTOR: 0.015, // Additional scaling per gear power point
   SPECIAL_ENEMY_SCALING_BONUS: 0.25, // Extra scaling for special enemies
   FLEE_CHANCE: 0.6, // 60% chance to flee successfully
   SPICE_SELL_COST: 50, // Spice required to sell


### PR DESCRIPTION
## Summary
- raise ENEMY_SCALING_FACTOR and GEAR_SCALING_FACTOR to give enemies a moderate stat boost as players progress

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8c916144832f9ec5826297bb4786