### PR TITLE
Improve map visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Recent additions to **Arrakis Spice Empire** include:
 =======
 - Defeating an enemy now grants your house control of the surrounding sectors.
 - Ability to sell unused gear for Solari.
+- Enlarged map view for easier risk-style territory control on both desktop and mobile.
 
 
 ## How It Works

--- a/app/globals.css
+++ b/app/globals.css
@@ -64,7 +64,7 @@ body {
 
 .map-grid {
   --map-columns: 15;
-  --cell-size: 32px;
+  --cell-size: 36px;
   display: grid;
   grid-template-columns: repeat(var(--map-columns), var(--cell-size));
   gap: 1px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -405,7 +405,7 @@ export default function ArrakisGamePage() {
   const [isLoading, setIsLoading] = useState(true)
   const [itemRespawnQueue, setItemRespawnQueue] = useState<Record<string, { item: Item; respawnTime: number }>>({})
   const [availableAbilitiesForSelection, setAvailableAbilitiesForSelection] = useState<Ability[]>([])
-  const [zoom, setZoom] = useState(1)
+  const [zoom, setZoom] = useState(1.2)
 
   const lastGeneralNotificationTime = useRef(0)
   const GENERAL_NOTIFICATION_COOLDOWN = 1000

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,7 +2,7 @@ import type { PlayerColor } from "@/types/game"
 
 export const CONFIG = {
   MAP_SIZE: 200,
-  VIEW_RADIUS: 7,
+  VIEW_RADIUS: 9,
   MAX_INVENTORY: 40,
   ENERGY_REGEN_RATE: 3,
   ENERGY_REGEN_INTERVAL: 2000,


### PR DESCRIPTION
## Summary
- make the map larger by default by expanding the view radius
- bump default cell size and default zoom
- document enlarged map in README

## Testing
- `npm install --legacy-peer-deps`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_683f8dadfd54832f8956e8c4e9044da2