### PR TITLE
Aggregate territory perks display

### DIFF
--- a/components/empire-tab.tsx
+++ b/components/empire-tab.tsx
@@ -240,11 +240,19 @@ export function EmpireTab({
         <h4 className="text-lg font-semibold text-amber-300 mb-2">Territory Perks</h4>
         {player.territories.length > 0 ? (
           <ul className="list-disc list-inside text-sm text-stone-300 space-y-1">
-            {player.territories
-              .flatMap((t) => t.perks)
-              .map((perk, i) => (
-                <li key={i}>{perk}</li>
-              ))}
+            {Object.entries(
+              player.territories
+                .flatMap((t) => t.perks)
+                .reduce((acc: Record<string, number>, perk) => {
+                  acc[perk] = (acc[perk] || 0) + 1
+                  return acc
+                }, {}),
+            ).map(([perk, count]) => (
+              <li key={perk}>
+                {perk}
+                {count > 1 ? ` (x${count})` : ""}
+              </li>
+            ))}
           </ul>
         ) : (
           <p className="text-sm text-stone-400">Acquire territories to gain passive bonuses to your empire.</p>


### PR DESCRIPTION
## Summary
- consolidate duplicate territory perks
- show combined perk counts in EmpireTab

## Testing
- `npm install --legacy-peer-deps` *(fails: code executed, but we got warnings due to dependency tree)*
- `npm run lint` *(fails: interactive lint config request)*

------
https://chatgpt.com/codex/tasks/task_e_683f942200b4832f91d8e38d24f1f080