### PR TITLE
Simplify map to risk-only gameplay

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -226,9 +226,9 @@ const getInitialResourcesState = (): Resources => ({
 
 const initialMapData = {
   enemies: generateMockEnemies(),
-  resources: generateMockResources(),
+  resources: {},
   territories: generateMockTerritories(),
-  items: generateMockItems(),
+  items: {},
 }
 
 // Function to create an AI player with initial state
@@ -403,7 +403,6 @@ const ENEMY_MOVEMENT_CONFIG = {
 export default function ArrakisGamePage() {
   const [gameState, setGameState] = useState<GameState>(initialGameState)
   const [isLoading, setIsLoading] = useState(true)
-  const [itemRespawnQueue, setItemRespawnQueue] = useState<Record<string, { item: Item; respawnTime: number }>>({})
   const [availableAbilitiesForSelection, setAvailableAbilitiesForSelection] = useState<Ability[]>([])
   const [zoom, setZoom] = useState(1.2)
 
@@ -726,8 +725,7 @@ export default function ArrakisGamePage() {
         })
         const enemyKey = `${enemyInstance.position.x},${enemyInstance.position.y}`
         if (newMap.enemies[enemyKey]) {
-          // Check if enemy still exists before updating
-          newMap.enemies[enemyKey] = { ...enemyInstance, cooldownUntil: Date.now() + CONFIG.ENEMY_COOLDOWN }
+          delete newMap.enemies[enemyKey]
         }
         if (currentFullGameState.capturingTerritoryId) {
           const terrKey = currentFullGameState.capturingTerritoryId
@@ -1234,8 +1232,6 @@ export default function ArrakisGamePage() {
         const newMap = {
           ...prev.map,
           enemies: { ...prev.map.enemies },
-          resources: { ...prev.map.resources },
-          items: { ...prev.map.items },
           territories: { ...prev.map.territories }, // Ensure territories are mutable
         }
         const newAbilityCooldowns = { ...prev.abilityCooldowns }
@@ -1296,32 +1292,7 @@ export default function ArrakisGamePage() {
         })
 
         // --- 2. Cooldowns & Respawns (Enemies, Resources, Items - existing logic) ---
-        Object.entries(newMap.enemies).forEach(([key, enemy]) => {
-          if (enemy.cooldownUntil && now >= enemy.cooldownUntil) {
-            const originalEnemyData = STATIC_DATA.ENEMIES[enemy.type as keyof typeof STATIC_DATA.ENEMIES]
-            newMap.enemies[key] = { ...enemy, currentHealth: originalEnemyData.health, cooldownUntil: null }
-          }
-        })
-        // (Resource and Item respawn logic - assuming it's largely correct from before)
-        // Item Respawn Logic (from original code)
-        const newRespawnQueue = { ...itemRespawnQueue }
-        Object.entries(newRespawnQueue).forEach(([itemId, { item, respawnTime }]) => {
-          if (now >= respawnTime) {
-            const { x, y } = getRandomMapCoords()
-            const newKey = `${x},${y}`
-            if (!newMap.items[newKey] && !newMap.enemies[newKey] && !newMap.resources[newKey]) {
-              // Check if cell is empty
-              newMap.items[newKey] = { ...item, id: `item_${newKey}`, position: { x, y } }
-              addNotification(`An item (${item.name}) has respawned at (${x},${y}).`, "info")
-              delete newRespawnQueue[itemId]
-            } else {
-              // Reschedule if cell is occupied
-              newRespawnQueue[itemId].respawnTime = now + 10000 // Try again in 10s
-            }
-          }
-        })
-        // No direct setItemRespawnQueue here, it's managed outside setGameState usually or returned.
-        // For simplicity, assume itemRespawnQueue is updated correctly if needed.
+        // Enemy cooldowns and item respawns removed for streamlined gameplay
 
         // --- 3. NEW: Dynamic World Event Management ---
         if (now - (prev.lastWorldEventProcessingTime || 0) >= 5000) {
@@ -1533,7 +1504,7 @@ export default function ArrakisGamePage() {
           // Link to player activity or fixed interval
           Object.keys(newMap.enemies).forEach((key) => {
             const enemy = newMap.enemies[key]
-            if (enemy && !enemy.cooldownUntil && !enemy.boss && !enemy.isMoving) {
+            if (enemy && !enemy.boss && !enemy.isMoving) {
               // Non-boss, active enemies
               if (Math.random() < ENEMY_MOVEMENT_CONFIG.MOVEMENT_CHANCE) {
                 const { x: ex, y: ey } = enemy.position
@@ -1726,8 +1697,6 @@ export default function ArrakisGamePage() {
         const dy = targetY - player.position.y
         const key = `${targetX},${targetY}`
         const enemyOnCell = map.enemies[key]
-        const resourceOnCell = map.resources[key]
-        const itemOnCell = map.items[key]
         const territoryOnCell = map.territories[key] // Get territory info
 
         // Check for AI player on the target cell
@@ -1805,7 +1774,7 @@ export default function ArrakisGamePage() {
 
         const newPlayer = { ...player }
         const newResources = { ...resources }
-        const newMap = { ...map, enemies: { ...map.enemies }, resources: { ...map.resources }, items: { ...map.items } }
+        const newMap = { ...map, enemies: { ...map.enemies } }
         const updatedInventory = [...prev.inventory]
 
         if (isMoving) {
@@ -1814,7 +1783,7 @@ export default function ArrakisGamePage() {
         }
 
         // Interaction logic (enemy, resource, item) remains largely the same
-        if (enemyOnCell && !enemyOnCell.cooldownUntil) {
+        if (enemyOnCell) {
           // ... (combat initiation logic from original, ensure it uses scaledEnemy correctly)
           const originalEnemyData = STATIC_DATA.ENEMIES[enemyOnCell.type as keyof typeof STATIC_DATA.ENEMIES]
           let targetEnemyLevel = player.level
@@ -1865,39 +1834,6 @@ export default function ArrakisGamePage() {
               enemyHealthAtStart: scaledEnemy.health,
               combatRound: 1,
             },
-          }
-        } else if (resourceOnCell && !resourceOnCell.cooldownUntil) {
-          // ... (resource harvesting logic from original)
-          let amountHarvested = Math.min(resourceOnCell.amount, 10)
-          if (player.activeAbility?.id === "spiceTrance") {
-            // Simplified check
-            amountHarvested = Math.floor(amountHarvested * (1 + (player.activeAbility.effectValue || 100) / 100))
-          }
-          ;(newResources as any)[resourceOnCell.type] += amountHarvested
-          addNotification(`Harvested ${amountHarvested} ${resourceOnCell.type}.`, "success")
-          newMap.resources[key] = {
-            ...resourceOnCell,
-            amount: resourceOnCell.amount - amountHarvested,
-          }
-          if (newMap.resources[key].amount <= 0) {
-            addNotification(`${resourceOnCell.type} node depleted. Will respawn elsewhere.`, "info")
-            newMap.resources[key].cooldownUntil = Date.now() + CONFIG.RESOURCE_DEPLETED_COOLDOWN // existing node stays on cooldown
-          }
-        } else if (itemOnCell) {
-          // ... (item pickup logic from original)
-          const emptySlotIndex = updatedInventory.findIndex((slot) => slot === null)
-          if (emptySlotIndex !== -1) {
-            updatedInventory[emptySlotIndex] = itemOnCell
-            delete newMap.items[key]
-            setItemRespawnQueue((prevQueue) => ({
-              ...prevQueue,
-              [itemOnCell.id!]: { item: itemOnCell, respawnTime: Date.now() + CONFIG.ITEM_RESPAWN_COOLDOWN },
-            }))
-            addNotification(`Picked up ${itemOnCell.icon} ${itemOnCell.name}.`, "success")
-          } else {
-            addNotification("Inventory is full! Could not pick up item.", "warning")
-            // If inventory full, don't consume movement cost / don't move player.
-            if (isMoving) return prev // Revert move if it happened
           }
         }
 
@@ -1956,7 +1892,7 @@ export default function ArrakisGamePage() {
         return { ...prev, player: newPlayer, resources: newResources, map: newMap, inventory: updatedInventory }
       })
     },
-    [addNotification, itemRespawnQueue, handleCombatEnd], // Ensure all dependencies are correct
+    [addNotification, handleCombatEnd],
   )
 
   // WASD Controls: Ensure it checks new modal flags if any are added for pausing. Fine for now.

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -67,13 +67,6 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
         if (territory.ownerId) hasBackground = true
       }
 
-      // Items (New)
-      const itemOnCell = mapData.items[key]
-      if (itemOnCell && cellContent === "") {
-        cellClass += " map-cell-item"
-        cellContent = itemOnCell.icon
-        cellTitle = `${itemOnCell.name} (${itemOnCell.rarity})`
-      }
 
       // Enemies
       const enemy = mapData.enemies[key]
@@ -84,15 +77,6 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
         hasBackground = true
       }
 
-      // Resources
-      const resource = mapData.resources[key]
-      if (resource && cellContent === "") {
-        cellClass += ` map-cell-resource-${resource.type}`
-        const icons = { spice: "✨", water: "💧", plasteel: "🔧", rareMaterials: "💎" }
-        cellContent = icons[resource.type] || "📦"
-        cellTitle = `${resource.type.charAt(0).toUpperCase() + resource.type.slice(1)} (${resource.amount})`
-        hasBackground = true
-      }
 
       // World Events Markers (can be an overlay on the cell)
       const eventOnCell = worldEvents.find((e) => e.position?.x === x && e.position?.y === y)


### PR DESCRIPTION
## Summary
- remove item and resource nodes from map generation
- delete enemies from the grid when defeated
- strip item/resource displays from the map grid
- drop related respawn logic and cooldown checks

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f9449d8a4832f94dbc0ab9bc47de3