### PR TITLE
Add trading modal to multiplayer hub

### DIFF
--- a/components/modals/trading-modal.tsx
+++ b/components/modals/trading-modal.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useState } from "react"
+import type { TradeOffer, Item } from "@/types/game"
+
+interface TradingModalProps {
+  isOpen: boolean
+  tradeOffers: TradeOffer[]
+  inventory: (Item | null)[]
+  playerId: string | null
+  playerSolari: number
+  onClose: () => void
+  onCreateOffer: (inventoryIndex: number, price: number) => void
+  onBuyOffer: (offerId: string) => void
+}
+
+export function TradingModal({
+  isOpen,
+  tradeOffers,
+  inventory,
+  playerId,
+  playerSolari,
+  onClose,
+  onCreateOffer,
+  onBuyOffer,
+}: TradingModalProps) {
+  const [selectedIndex, setSelectedIndex] = useState(-1)
+  const [price, setPrice] = useState(0)
+
+  if (!isOpen) return null
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-content max-w-2xl">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-stone-400 hover:text-white text-2xl font-bold"
+          aria-label="Close"
+        >
+          &times;
+        </button>
+        <h3 className="text-2xl font-orbitron text-amber-400 mb-4 text-center">
+          Trade Network
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <h4 className="text-lg font-semibold text-amber-300 mb-2">Create Offer</h4>
+            {inventory.filter((i) => i).length === 0 ? (
+              <p className="text-sm text-stone-400 mb-4">No items in inventory.</p>
+            ) : (
+              <div className="space-y-3">
+                <select
+                  className="w-full px-3 py-2 bg-stone-700 border border-stone-600 rounded-md text-stone-200"
+                  value={selectedIndex}
+                  onChange={(e) => setSelectedIndex(parseInt(e.target.value))}
+                >
+                  <option value={-1}>Select Item</option>
+                  {inventory.map((item, idx) =>
+                    item ? (
+                      <option key={idx} value={idx}>
+                        {item.icon} {item.name}
+                      </option>
+                    ) : null,
+                  )}
+                </select>
+                <input
+                  type="number"
+                  min={1}
+                  className="w-full px-3 py-2 bg-stone-700 border border-stone-600 rounded-md text-stone-200"
+                  placeholder="Price in Solari"
+                  value={price}
+                  onChange={(e) => setPrice(parseInt(e.target.value))}
+                />
+                <button
+                  onClick={() => {
+                    if (selectedIndex >= 0 && price > 0) {
+                      onCreateOffer(selectedIndex, price)
+                      setSelectedIndex(-1)
+                      setPrice(0)
+                    }
+                  }}
+                  disabled={selectedIndex < 0 || price <= 0}
+                  className="w-full py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-md disabled:bg-stone-500"
+                >
+                  List Item
+                </button>
+              </div>
+            )}
+          </div>
+          <div>
+            <h4 className="text-lg font-semibold text-amber-300 mb-2">Available Offers</h4>
+            {tradeOffers.length === 0 ? (
+              <p className="text-sm text-stone-400">No trade offers available.</p>
+            ) : (
+              <ul className="space-y-3 max-h-72 overflow-y-auto">
+                {tradeOffers.map((offer) => (
+                  <li
+                    key={offer.id}
+                    className="p-3 border border-stone-600 rounded trading-item"
+                  >
+                    <div className="flex justify-between items-center">
+                      <span>
+                        {offer.item.icon} {offer.item.name} - {offer.price} Solari
+                      </span>
+                      <span className={`player-color-${offer.sellerColor}`}>{offer.sellerName}</span>
+                    </div>
+                    {offer.sellerId !== playerId && (
+                      <button
+                        className="mt-2 w-full py-1 bg-amber-600 hover:bg-amber-700 text-sm rounded disabled:bg-stone-500"
+                        onClick={() => onBuyOffer(offer.id)}
+                        disabled={playerSolari < offer.price}
+                      >
+                        Buy
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/trade-panel.tsx
+++ b/components/trade-panel.tsx
@@ -5,9 +5,10 @@ import type { Player, Resources } from "@/types/game"
 interface TradePanelProps {
   player: Player
   resources: Resources
+  onOpenTrading: () => void
 }
 
-export function TradePanel({ player, resources }: TradePanelProps) {
+export function TradePanel({ player, resources, onOpenTrading }: TradePanelProps) {
   return (
     <div className="bg-stone-800 p-6 rounded-lg border border-stone-600">
       <h3 className="text-xl font-semibold mb-4 text-amber-300">🤝 Interstellar Trade Network</h3>
@@ -51,10 +52,10 @@ export function TradePanel({ player, resources }: TradePanelProps) {
         </div>
       </div>
       <button
-        className="w-full mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-md transition duration-150 ease-in-out disabled:bg-stone-500 disabled:cursor-not-allowed"
-        disabled
+        className="w-full mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-md transition duration-150 ease-in-out"
+        onClick={onOpenTrading}
       >
-        Browse Trade Offers (Coming Soon)
+        Browse Trade Offers
       </button>
     </div>
   )

--- a/types/game.ts
+++ b/types/game.ts
@@ -192,6 +192,15 @@ export interface ChatMessage {
   message: string
 }
 
+export interface TradeOffer {
+  id: string
+  sellerId: string | null
+  sellerName: string
+  sellerColor: string
+  item: Item
+  price: number
+}
+
 export interface Ability {
   id: string
   name: string
@@ -221,7 +230,7 @@ export interface GameState {
   // onlinePlayers: Record<string, Partial<Player & { position: { x: number; y: number } }>> // Old
   onlinePlayers: Record<string, AIPlayer> // NEW: AIs have their own full Player state and Resources
   worldEvents: WorldEvent[]
-  tradeOffers: any[]
+  tradeOffers: TradeOffer[]
   map: {
     enemies: Record<string, Enemy>
     resources: Record<string, ResourceNode>


### PR DESCRIPTION
## Summary
- add `TradeOffer` type and update `GameState` tradeOffers type
- create TradingModal component for listing and creating trade offers
- enable the Browse Trade Offers button and pass handler via props
- manage trade offer creation and purchase in game state

## Testing
- `pnpm install`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683fa54d7fdc832f9228c6f62bc54fad