### PR TITLE
Add scroll zoom and expand map

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2527,6 +2527,7 @@ export default function ArrakisGamePage() {
                   worldEvents={gameState.worldEvents} // Pass dynamic world events
                   onCellClick={handleMapCellClick}
                   zoom={zoom}
+                  onZoomChange={setZoom}
                 />
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
                   <Leaderboard topPlayers={gameState.leaderboard} />

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -10,9 +10,18 @@ interface MapGridProps {
   worldEvents: GameState["worldEvents"]
   onCellClick: (x: number, y: number) => void
   zoom?: number
+  onZoomChange?: (zoom: number) => void
 }
 
-export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellClick, zoom = 1 }: MapGridProps) {
+export function MapGrid({
+  player,
+  mapData,
+  onlinePlayers,
+  worldEvents,
+  onCellClick,
+  zoom = 1,
+  onZoomChange,
+}: MapGridProps) {
   const { x: playerX, y: playerY } = player.position
   const radius = CONFIG.VIEW_RADIUS
 
@@ -136,8 +145,20 @@ export function MapGrid({ player, mapData, onlinePlayers, worldEvents, onCellCli
     "--map-columns": radius * 2 + 1,
   } as React.CSSProperties
 
+  const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (!onZoomChange) return
+    e.preventDefault()
+    const delta = e.deltaY > 0 ? -0.1 : 0.1
+    const newZoom = Math.min(2, Math.max(0.5, zoom + delta))
+    onZoomChange(Number(newZoom.toFixed(2)))
+  }
+
   return (
-    <div className="map-grid mx-auto overflow-x-auto" style={gridStyle}>
+    <div
+      className="map-grid mx-auto overflow-x-auto"
+      style={gridStyle}
+      onWheel={handleWheel}
+    >
       {cells}
     </div>
   )

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,8 +1,8 @@
-import type { PlayerColor } from "@/types/game"
+import type { PlayerColor } from "@/types/game";
 
 export const CONFIG = {
   MAP_SIZE: 200,
-  VIEW_RADIUS: 9,
+  VIEW_RADIUS: 15,
   MAX_INVENTORY: 40,
   ENERGY_REGEN_RATE: 3,
   ENERGY_REGEN_INTERVAL: 2000,
@@ -47,7 +47,7 @@ export const CONFIG = {
   SANDWORM_COUNTDOWN: 10000, // Countdown duration after warning
   SEEKER_COST: 5000,
   SEEKER_COOLDOWN: 60000,
-}
+};
 
 export const PLAYER_COLORS = [
   "red",
@@ -58,13 +58,13 @@ export const PLAYER_COLORS = [
   "pink",
   "yellow",
   "cyan",
-]
+];
 
 export const HOUSE_COLORS: Record<string, PlayerColor> = {
   atreides: "blue",
   harkonnen: "red",
   fremen: "green",
-}
+};
 
 export const DUNE_QUOTES = [
   "Fear is the mind-killer.",
@@ -77,7 +77,7 @@ export const DUNE_QUOTES = [
   "Without change, something sleeps inside us, and seldom awakens.",
   "The future remains uncertain and so it should, for it is the canvas upon which we paint our desires.",
   "Bless the Maker and His water. Bless the coming and going of Him.",
-]
+];
 
 export const RARITY_SCORES = {
   common: 1,
@@ -85,4 +85,4 @@ export const RARITY_SCORES = {
   rare: 3,
   epic: 4,
   legendary: 5,
-}
+};


### PR DESCRIPTION
## Summary
- expand map view radius for larger map
- allow MapGrid wheel zooming
- hook zoom wheel into the page

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5edf13c832facdec09ce839e280