### PR TITLE
Implement XP buff on player victories

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -213,6 +213,8 @@ const getInitialPlayerState = (id: string | null, prestigeLevel = 0): Player => 
     unlockedAbilities: [],
     activeAbility: null,
     isDefending: false,
+    xpBuffMultiplier: 1,
+    xpBuffExpires: null,
   }
 }
 
@@ -677,10 +679,14 @@ export default function ArrakisGamePage() {
         territories: { ...mapState.territories },
       } // Be careful with deep copies if needed
       const updatedInventory = [...currentFullGameState.inventory] // Use inventory from the ref
+      const now = Date.now()
 
       if (result === "win") {
         let xpGained = enemyInstance.xp
         xpGained = Math.floor(xpGained * newPlayer.globalGainMultiplier)
+        if (newPlayer.xpBuffExpires && newPlayer.xpBuffExpires > now) {
+          xpGained = Math.floor(xpGained * (newPlayer.xpBuffMultiplier || 1))
+        }
         if (newPlayer.house === "atreides") {
           xpGained = Math.floor(xpGained * 1.25)
         }
@@ -735,6 +741,11 @@ export default function ArrakisGamePage() {
         if (newMap.enemies[enemyKey]) {
           delete newMap.enemies[enemyKey]
         }
+        if (enemyInstance.type === "player") {
+          newPlayer.xpBuffMultiplier = 1.5
+          newPlayer.xpBuffExpires = now + 60000
+          addNotification("XP Buff! +50% for 1 minute", "legendary")
+        }
         if (currentFullGameState.capturingTerritoryId) {
           const terrKey = currentFullGameState.capturingTerritoryId
           const terr = newMap.territories[terrKey]
@@ -756,6 +767,11 @@ export default function ArrakisGamePage() {
               )
             }
             addNotification(`You captured ${terr.name || terrKey}!`, "success")
+            if (oldOwner && oldOwner !== newPlayer.id && enemyInstance.type !== "player") {
+              newPlayer.xpBuffMultiplier = 1.5
+              newPlayer.xpBuffExpires = now + 60000
+              addNotification("XP Buff! +50% for 1 minute", "legendary")
+            }
           }
         }
 
@@ -1250,6 +1266,12 @@ export default function ArrakisGamePage() {
         const newOnlinePlayers = JSON.parse(JSON.stringify(prev.onlinePlayers)) // Deep copy for AI modifications
         let sandwormAttackTime = prev.sandwormAttackTime
 
+        if (newPlayer.xpBuffExpires && now >= newPlayer.xpBuffExpires) {
+          newPlayer.xpBuffMultiplier = 1
+          newPlayer.xpBuffExpires = null
+          newNotifications.push({ id: now.toString(), message: "XP Buff expired", type: "info" })
+        }
+
         // --- 1. Player Stat Regen & Income (mostly existing logic) ---
         if (now - prev.lastEnergyRegen >= CONFIG.ENERGY_REGEN_INTERVAL) {
           let energyRegenRate = newPlayer.energyProductionRate
@@ -1464,8 +1486,17 @@ export default function ArrakisGamePage() {
                 // Apply immediate rewards
                 if (newEvent.rewards.spice) newResources.spice += newEvent.rewards.spice
                 if (newEvent.rewards.solari) newResources.solari += newEvent.rewards.solari
-                // ... etc for all resources & xp
-                if (newEvent.rewards.xp) newPlayer.experience += newEvent.rewards.xp // (Handle level up if necessary)
+                if (newEvent.rewards.xp) {
+                  let eventXP = newEvent.rewards.xp
+                  eventXP = Math.floor(eventXP * newPlayer.globalGainMultiplier)
+                  if (newPlayer.xpBuffExpires && newPlayer.xpBuffExpires > now) {
+                    eventXP = Math.floor(eventXP * (newPlayer.xpBuffMultiplier || 1))
+                  }
+                  if (newPlayer.house === "atreides") {
+                    eventXP = Math.floor(eventXP * 1.25)
+                  }
+                  newPlayer.experience += eventXP
+                }
                 addNotification("You received event rewards!", "success")
               }
             }

--- a/components/character-tab.tsx
+++ b/components/character-tab.tsx
@@ -24,7 +24,9 @@ export function CharacterTab({
   onActivateAbility,
   abilityCooldowns,
 }: CharacterTabProps) {
-  const totalXPGainBonus = (player.globalGainMultiplier - 1 + (player.house === "atreides" ? 0.25 : 0)) * 100
+  const xpBuff = player.xpBuffExpires && player.xpBuffExpires > Date.now() ? player.xpBuffMultiplier || 1 : 1
+  const totalXPGainBonus =
+    (player.globalGainMultiplier * xpBuff * (player.house === "atreides" ? 1.25 : 1) - 1) * 100
 
   const stats = [
     { label: "Attack Power", value: player.attack, color: "text-red-400" },

--- a/types/game.ts
+++ b/types/game.ts
@@ -34,6 +34,8 @@ export interface Player {
   unlockedAbilities: Ability[]
   activeAbility: Ability | null
   isDefending: boolean
+  xpBuffMultiplier?: number
+  xpBuffExpires?: number | null
   // NEW: For AI resource tracking, we will add 'resources' directly to the AI player object in GameState.onlinePlayers.
   // No change to Player type itself is strictly needed if AIs in onlinePlayers are Partial<Player> & {resources: Resources}
   equipment?: Equipment // Added for AI ranking


### PR DESCRIPTION
## Summary
- add XP buff fields to Player type
- initialize buff status for players
- handle buff activation on player kill or territory capture
- expire XP buff in the game tick
- show current XP gain bonus including buff

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa6ea42b4832fac3ce766985478fa