### PR TITLE
Add quest system with simple goals

### DIFF
--- a/components/quest-panel.tsx
+++ b/components/quest-panel.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import type { Quest } from "@/types/game"
+
+interface QuestPanelProps {
+  quests: Quest[]
+}
+
+export function QuestPanel({ quests }: QuestPanelProps) {
+  return (
+    <div className="bg-stone-700 p-4 rounded-lg border border-green-500">
+      <h3 className="text-lg font-semibold text-green-400 mb-3 font-orbitron">📝 Quests</h3>
+      <div className="space-y-2 text-sm">
+        {quests.length === 0 && (
+          <p className="text-stone-300 text-center">No quests</p>
+        )}
+        {quests.map((q) => (
+          <div key={q.id} className="p-2 bg-stone-600 rounded">
+            <div className="flex justify-between mb-1">
+              <span>{q.description}</span>
+              <span className="font-mono">
+                {q.progress}/{q.goal}
+              </span>
+            </div>
+            <div className="progress-bar-bg rounded h-2">
+              <div
+                className="bg-green-500 h-full rounded"
+                style={{ width: `${(q.progress / q.goal) * 100}%` }}
+              ></div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/types/game.ts
+++ b/types/game.ts
@@ -204,6 +204,15 @@ export interface Ability {
   effectValue: number
 }
 
+export interface Quest {
+  id: string
+  description: string
+  type: "kill" | "territory" | "move"
+  goal: number
+  progress: number
+  completed: boolean
+}
+
 // Modified onlinePlayers to include full Player type and their own Resources
 export type AIPlayer = Player & { resources: Resources }
 
@@ -251,6 +260,8 @@ export interface GameState {
   // NEW: Timestamp when sandworm will attack if player stays idle
   sandwormAttackTime?: number | null
   lastSeekerLaunchTime?: number
+  quests: Quest[]
+  completedQuests: Quest[]
 }
 
 export type PlayerColor = "red" | "blue" | "green" | "purple" | "orange" | "pink" | "yellow" | "cyan"


### PR DESCRIPTION
## Summary
- define `Quest` type and extend `GameState`
- generate random quests and store in state
- implement quest progress updates for moving, killing enemies and gaining territory
- show active quests via new `QuestPanel` component

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_683fa7142284832f90ed51b674f2a998