### PR TITLE
Rename Shai-Hulud boss

### DIFF
--- a/lib/game-data.ts
+++ b/lib/game-data.ts
@@ -124,7 +124,7 @@ export const STATIC_DATA = {
       description: "The Baron himself. Master of schemes.",
     },
     sandworm: {
-      name: "Shai-Hulud",
+      name: "Infant Sandworm",
       icon: "🐛",
       health: 2000, // Increased from 1400
       attack: 110,
@@ -406,10 +406,10 @@ export const STATIC_DATA = {
       effect: "sandworm_attack",
       duration: 60000, // Short duration before attack
       type: "hazard",
-      triggersNext: "Shai-Hulud Attack", // Triggers the actual attack event
+      triggersNext: "Infant Sandworm Attack", // Triggers the actual attack event
     },
     {
-      name: "Shai-Hulud Attack",
+      name: "Infant Sandworm Attack",
       description: "A sandworm attacks a random territory!",
       icon: "💥",
       effect: "territory_destruction", // New effect type

--- a/types/game.ts
+++ b/types/game.ts
@@ -178,7 +178,7 @@ export interface WorldEvent extends MapElement {
   duration?: number
   endTime?: number
   type?: "economy" | "hazard" | "diplomacy" | "political" // For categorization
-  // NEW: For event chaining (e.g. Wormsign -> ShaiHuludAttack)
+  // NEW: For event chaining (e.g. Wormsign -> InfantSandwormAttack)
   triggersNext?: string // Key of the next event to trigger
   isChainedEvent?: boolean // If this event was triggered by another
   // NEW: For Sandworm attack target


### PR DESCRIPTION
## Summary
- rename the Shai-Hulud boss to Infant Sandworm
- update the worm attack event to match new name
- tweak comment example in `types/game.ts`

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683faa1a685c832f83a24895de688d8c