### PR TITLE
Add normal enemy types and rebalance special foes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -172,8 +172,7 @@ body {
 .map-cell-boss {
   background: linear-gradient(135deg, #7e22ce, #6b21a8) !important;
   color: white !important;
-  animation: pulse-boss 2s infinite alternate;
-  box-shadow: 0 0 15px #7e22ce; /* Added distinct shadow */
+  animation: none;
 }
 
 .map-cell-special-enemy {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2106,7 +2106,10 @@ export default function ArrakisGamePage() {
             (player.equipment?.accessory?.attack || 0) +
             (player.equipment?.accessory?.defense || 0)
           const gearMultiplier = 1 + gearPower * CONFIG.GEAR_SCALING_FACTOR
-          const baseScaling = Math.max(0.1, 1 + levelDifference * CONFIG.ENEMY_SCALING_FACTOR)
+          const scalingFactor = originalEnemyData.special
+            ? CONFIG.SPECIAL_ENEMY_SCALING_FACTOR
+            : CONFIG.NORMAL_ENEMY_SCALING_FACTOR
+          const baseScaling = Math.max(0.1, 1 + levelDifference * scalingFactor)
           const specialBonus = originalEnemyData.special ? 1 + CONFIG.SPECIAL_ENEMY_SCALING_BONUS : 1
           const scalingMultiplier = baseScaling * gearMultiplier * specialBonus
 

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -80,7 +80,9 @@ export function MapGrid({
       // Enemies
       const enemy = mapData.enemies[key]
       if (enemy && cellContent === "") {
-        cellClass += enemy.boss ? " map-cell-boss" : enemy.special ? " map-cell-special-enemy" : " map-cell-enemy"
+        if (enemy.special) cellClass += " map-cell-special-enemy"
+        else if (enemy.boss) cellClass += " map-cell-boss"
+        else cellClass += " map-cell-enemy"
         cellContent = enemy.icon
         cellTitle = `${enemy.name} (Lv.${enemy.level})`
         hasBackground = true

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -22,9 +22,10 @@ export const CONFIG = {
   COMBAT_TURN_DELAY: 1500, // Delay between turns in combat (ms) - This is now just a visual delay for enemy action
   // Removed COMBAT_MINIGAME_DURATION, COMBAT_TURN_DURATION
   // Slightly higher scaling so enemies keep up with player progression
-  ENEMY_SCALING_FACTOR: 0.2, // 20% stat increase per level difference
+  NORMAL_ENEMY_SCALING_FACTOR: 0.15, // Scaling for normal enemies
+  SPECIAL_ENEMY_SCALING_FACTOR: 0.25, // Higher scaling for special enemies
   GEAR_SCALING_FACTOR: 0.015, // Additional scaling per gear power point
-  SPECIAL_ENEMY_SCALING_BONUS: 0.25, // Extra scaling for special enemies
+  SPECIAL_ENEMY_SCALING_BONUS: 0.4, // Extra scaling multiplier for special enemies
   FLEE_CHANCE: 0.6, // 60% chance to flee successfully
   SPICE_SELL_COST: 50, // Spice required to sell
   SPICE_SELL_YIELD: 50, // Solari gained from selling spice

--- a/lib/game-data.ts
+++ b/lib/game-data.ts
@@ -23,6 +23,30 @@ export const STATIC_DATA = {
     },
   },
   ENEMIES: {
+    desertScavenger: {
+      name: "Desert Scavenger",
+      icon: "🦂",
+      health: 40,
+      attack: 8,
+      defense: 5,
+      xp: 40,
+      loot: { solari: 20, spice: 5, water: 8 },
+      level: 1,
+      spawnChance: 0.6,
+      description: "Opportunistic wanderer searching the dunes for valuables.",
+    },
+    spiceBandit: {
+      name: "Spice Bandit",
+      icon: "🥾",
+      health: 60,
+      attack: 12,
+      defense: 7,
+      xp: 60,
+      loot: { solari: 45, spice: 15 },
+      level: 2,
+      spawnChance: 0.25,
+      description: "Thief looking to steal freshly harvested spice.",
+    },
     sandRaider: {
       name: "Fremen Raider",
       icon: "🏹",
@@ -74,26 +98,26 @@ export const STATIC_DATA = {
     guildNavigator: {
       name: "Guild Navigator",
       icon: "👁️",
-      health: 250, // Increased from 190
-      attack: 24,
-      defense: 20,
-      xp: 250,
+      health: 300,
+      attack: 32,
+      defense: 26,
+      xp: 300,
       loot: { melange: 10, rareMaterials: 10, solari: 250 },
       level: 7, // Base level
-      spawnChance: 0.008, // Very rare
+      spawnChance: 0.004,
       special: true,
       description: "Mutated spice addict with prescient abilities.",
     },
     mentat: {
       name: "Corrupted Mentat",
       icon: "🧠",
-      health: 220, // Increased from 170
-      attack: 32,
-      defense: 12,
-      xp: 220,
+      health: 260,
+      attack: 40,
+      defense: 18,
+      xp: 260,
       loot: { solari: 180, melange: 6, rareMaterials: 7 },
       level: 6, // Base level
-      spawnChance: 0.008, // Very rare
+      spawnChance: 0.004,
       special: true,
       description: "Human computer driven mad by forbidden calculations.",
     },
@@ -140,14 +164,14 @@ export const STATIC_DATA = {
     reverendMother: {
       name: "Reverend Mother Mohiam",
       icon: "🧙",
-      health: 800,
-      attack: 60,
-      defense: 30,
-      xp: 700,
+      health: 900,
+      attack: 75,
+      defense: 40,
+      xp: 800,
       loot: { melange: 50, rareMaterials: 25, solari: 2000 },
       boss: true,
       level: 15,
-      spawnChance: 0.0015, // Very rare
+      spawnChance: 0.0008,
       special: true,
       description: "Bene Gesserit matriarch wielding the Voice.",
     },


### PR DESCRIPTION
## Summary
- introduce Desert Scavenger and Spice Bandit as new normal foes
- buff special enemy stats and lower their spawn chances
- tweak scaling factors for normal vs. special enemies
- only special enemies glow on the map
- ensure bosses no longer glow and special status takes priority

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fab2e8068832fb1f293b6218bb441