### PR TITLE
Fix equipment swapping and add item tooltips

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -437,6 +437,22 @@ export default function ArrakisGamePage() {
     lastGeneralNotificationTime.current = now
   }, [])
 
+  const addWorldChatMessage = useCallback((message: string) => {
+    setGameState((prev) => ({
+      ...prev,
+      chatMessages: [
+        ...prev.chatMessages,
+        {
+          senderId: "system",
+          senderName: "System",
+          senderColor: "yellow",
+          timestamp: { seconds: Math.floor(Date.now() / 1000), nanoseconds: 0 },
+          message,
+        },
+      ],
+    }))
+  }, [])
+
   const updateQuestProgress = useCallback((type: Quest["type"], amount = 1) => {
     setGameState((prev) => {
       let quests = prev.quests.map((q) => {
@@ -762,6 +778,9 @@ export default function ArrakisGamePage() {
             if (emptySlotIndex !== -1) {
               updatedInventory[emptySlotIndex] = itemData
               addNotification(`You found a ${itemData.icon} ${itemData.name}!`, "success")
+              if (itemData.rarity === "epic" || itemData.rarity === "legendary") {
+                addWorldChatMessage(`${newPlayer.name} found an ${itemData.rarity} ${itemData.name}!`)
+              }
             } else {
               addNotification(`Inventory full! Could not pick up ${itemData.name}.`, "warning")
             }
@@ -2444,23 +2463,12 @@ export default function ArrakisGamePage() {
         const newEquipment = { ...prev.equipment }
         const newInventory = [...prev.inventory]
 
-        const currentEquippedItem = newEquipment[item.type as keyof typeof newEquipment]
+        const slot = item.type as keyof typeof newEquipment
+        const currentEquippedItem = newEquipment[slot]
 
-        // Unequip current item if slot is occupied and it's different from the new item
-        if (currentEquippedItem && currentEquippedItem.id !== item.id) {
-          const emptySlotIndex = newInventory.findIndex((slot) => slot === null)
-          if (emptySlotIndex !== -1) {
-            newInventory[emptySlotIndex] = currentEquippedItem
-            addNotification(`Unequipped ${currentEquippedItem.name}.`, "info")
-          } else {
-            addNotification("Inventory full! Cannot unequip current item.", "warning")
-            return prev // Cannot unequip, so cannot equip new item
-          }
-        }
-
-        // Equip the new item
-        newEquipment[item.type as keyof typeof newEquipment] = item
-        newInventory[inventoryIndex] = null // Remove item from inventory
+        // Swap the equipped item with the inventory item
+        newEquipment[slot] = item
+        newInventory[inventoryIndex] = currentEquippedItem || null
 
         // Update player stats based on equipped item
         newPlayer.attack = initialGameState.player.attack + (newEquipment.weapon?.attack || 0)

--- a/components/character-tab.tsx
+++ b/components/character-tab.tsx
@@ -2,6 +2,12 @@
 
 import type { Player, Equipment, Item, Ability, Resources } from "@/types/game"
 import { CONFIG, CRAFTING_RECIPES } from "@/lib/constants" // For MAX_INVENTORY and crafting costs
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip"
 
 interface CharacterTabProps {
   player: Player
@@ -67,43 +73,62 @@ export function CharacterTab({
         {/* Equipment and Inventory */}
         <div className="bg-stone-800 p-6 rounded-lg border border-stone-600">
           <h3 className="text-xl font-semibold mb-4 text-amber-300">Equipment</h3>
-          <div className="grid grid-cols-3 gap-4 text-center mb-6">
-            {(Object.keys(equipment) as Array<keyof Equipment>).map((slot) => {
-              const eqItem = equipment[slot]
-              return (
-                <div key={slot}>
-                  <div
-                    title={eqItem ? getItemTooltip(eqItem) : "Empty"}
-                    className={`inventory-slot mx-auto mb-2 w-16 h-16 ${eqItem ? `rarity-${eqItem.rarity}` : ""}`}
-                  >
-                    {eqItem?.icon || ""}
+          <TooltipProvider delayDuration={0}>
+            <div className="grid grid-cols-3 gap-4 text-center mb-6">
+              {(Object.keys(equipment) as Array<keyof Equipment>).map((slot) => {
+                const eqItem = equipment[slot]
+                return (
+                  <div key={slot}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div
+                          className={`inventory-slot mx-auto mb-2 w-16 h-16 ${eqItem ? `rarity-${eqItem.rarity}` : ""}`}
+                        >
+                          {eqItem?.icon || ""}
+                        </div>
+                      </TooltipTrigger>
+                      {eqItem && (
+                        <TooltipContent>
+                          <div className="whitespace-pre-line">{getItemTooltip(eqItem)}</div>
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                    <span className="text-sm font-semibold capitalize">{slot}</span>
                   </div>
-                  <span className="text-sm font-semibold capitalize">{slot}</span>
-                </div>
-              )
-            })}
-          </div>
+                )
+              })}
+            </div>
+          </TooltipProvider>
 
           <h3 className="text-xl font-semibold mb-4 text-amber-300">
             Inventory ({inventory.filter((i) => i).length}/{CONFIG.MAX_INVENTORY})
           </h3>
-          <div className="grid grid-cols-5 sm:grid-cols-8 gap-2">
-            {inventory.map((item, index) => (
-              <div
-                key={index}
-                title={item ? getItemTooltip(item) : "Empty Slot"}
-                className={`inventory-slot ${item ? `rarity-${item.rarity} cursor-pointer hover:border-amber-500` : "opacity-50"}`}
-                onClick={() => item && onEquipItem(item, index)}
-                onContextMenu={(e) => {
-                  if (!item) return
-                  e.preventDefault()
-                  onSellItem(item, index)
-                }}
-              >
-                {item?.icon || ""}
-              </div>
-            ))}
-          </div>
+          <TooltipProvider delayDuration={0}>
+            <div className="grid grid-cols-5 sm:grid-cols-8 gap-2">
+              {inventory.map((item, index) => (
+                <Tooltip key={index}>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={`inventory-slot ${item ? `rarity-${item.rarity} cursor-pointer hover:border-amber-500` : "opacity-50"}`}
+                      onClick={() => item && onEquipItem(item, index)}
+                      onContextMenu={(e) => {
+                        if (!item) return
+                        e.preventDefault()
+                        onSellItem(item, index)
+                      }}
+                    >
+                      {item?.icon || ""}
+                    </div>
+                  </TooltipTrigger>
+                  {item && (
+                    <TooltipContent>
+                      <div className="whitespace-pre-line">{getItemTooltip(item)}</div>
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              ))}
+            </div>
+          </TooltipProvider>
           <p className="text-xs text-stone-400 mt-3">Click an item to equip. Right-click to sell.</p>
         </div>
 


### PR DESCRIPTION
## Summary
- fix equip logic so items swap instead of deleting
- add elegant tooltips for equipped and inventory items
- announce to world chat when players find epic or legendary loot

## Testing
- `pnpm lint` *(fails: ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_e_683faaba04a8832fab24fe07d8f487cd