### PR TITLE
Adjust seeker drone requirements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2446,6 +2446,13 @@ export default function ArrakisGamePage() {
 
       const newResources = { ...prev.resources }
       const newPlayer = { ...prev.player }
+      if (newPlayer.level < CONFIG.SEEKER_LEVEL_REQUIRED) {
+        addNotification(
+          `Reach level ${CONFIG.SEEKER_LEVEL_REQUIRED} to launch a Seeker!`,
+          "warning",
+        )
+        return prev
+      }
       if (newResources.solari < CONFIG.SEEKER_COST) {
         addNotification(`Need ${CONFIG.SEEKER_COST.toLocaleString()} Solari to launch a Seeker!`, "warning")
         return prev

--- a/components/empire-tab.tsx
+++ b/components/empire-tab.tsx
@@ -263,9 +263,12 @@ export function EmpireTab({
       <div className="mt-6">
         <button
           onClick={onLaunchSeeker}
-          disabled={resources.solari < CONFIG.SEEKER_COST}
+          disabled={
+            resources.solari < CONFIG.SEEKER_COST ||
+            player.level < CONFIG.SEEKER_LEVEL_REQUIRED
+          }
           className="w-full py-3 bg-red-600 hover:bg-red-700 rounded font-bold mb-3 disabled:bg-stone-600"
-          title={`Costs ${CONFIG.SEEKER_COST.toLocaleString()} Solari`}
+          title={`Costs ${CONFIG.SEEKER_COST.toLocaleString()} Solari | Requires level ${CONFIG.SEEKER_LEVEL_REQUIRED}`}
         >
           Launch Seeker Drone
         </button>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -46,7 +46,8 @@ export const CONFIG = {
   OWNED_TERRITORY_COST_MULTIPLIER: 5, // Multiplier if the random territory is already owned
   IDLE_TIME_BEFORE_WORM: 120000, // 2 minutes of inactivity before warning
   SANDWORM_COUNTDOWN: 10000, // Countdown duration after warning
-  SEEKER_COST: 5000,
+  SEEKER_COST: 1000,
+  SEEKER_LEVEL_REQUIRED: 7,
   SEEKER_COOLDOWN: 60000,
   TRACK_COST_PLASTEEL: 50,
   BOUNTY_INCREMENT: 100,


### PR DESCRIPTION
## Summary
- lower Seeker Drone cost to 1000 Solari
- require level 7 for Seeker Drone
- gate Launch Seeker button and action behind new level check

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc855d13c832f84e8c63becee38f0