### PR TITLE
Improve world chat usability

### DIFF
--- a/components/world-chat.tsx
+++ b/components/world-chat.tsx
@@ -1,62 +1,85 @@
-"use client"
+"use client";
 
-import type { ChatMessage } from "@/types/game"
-import type React from "react"
-import { useState, useRef, useEffect } from "react"
+import type { ChatMessage } from "@/types/game";
+import type React from "react";
+import { useState, useRef, useEffect } from "react";
 
 interface WorldChatProps {
-  messages: ChatMessage[]
-  onSendMessage: (message: string) => void
-  playerName: string
-  playerColor: string
+  messages: ChatMessage[];
+  onSendMessage: (message: string) => void;
+  playerName: string;
+  playerColor: string;
 }
 
-export function WorldChat({ messages, onSendMessage, playerName, playerColor }: WorldChatProps) {
-  const [inputMessage, setInputMessage] = useState("")
-  const messagesEndRef = useRef<HTMLDivElement>(null)
-  const chatContainerRef = useRef<HTMLDivElement>(null)
+export function WorldChat({
+  messages,
+  onSendMessage,
+  playerName,
+  playerColor,
+}: WorldChatProps) {
+  const [inputMessage, setInputMessage] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const chatContainerRef = useRef<HTMLDivElement>(null);
+
+  // Ensure newest messages are visible on mount and whenever the messages array
+  // updates. This keeps the chat scrolled to the bottom so players always see
+  // the latest chat activity when switching to the multiplayer tab or when a
+  // new message arrives.
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
 
   useEffect(() => {
-    const chatContainer = chatContainerRef.current
-    if (chatContainer) {
-      // Check if the user is already scrolled to the bottom or very close
-      const isAtBottom = chatContainer.scrollHeight - chatContainer.clientHeight <= chatContainer.scrollTop + 1 // +1 for tolerance
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
 
-      if (isAtBottom) {
-        messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-      }
-    }
-  }, [messages]) // Only re-run when messages change
-
-  const handleSend = (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSend = (e: React.FormEvent | React.KeyboardEvent) => {
+    e.preventDefault();
     if (inputMessage.trim()) {
-      onSendMessage(inputMessage)
-      setInputMessage("")
+      onSendMessage(inputMessage);
+      setInputMessage("");
     }
-  }
+  };
 
   return (
     <div className="flex flex-col h-[400px] bg-stone-800 rounded-lg border border-stone-600">
-      <div ref={chatContainerRef} className="flex-1 overflow-y-auto p-4 space-y-2 text-sm custom-scrollbar">
+      <div
+        ref={chatContainerRef}
+        className="flex-1 overflow-y-auto p-4 space-y-2 text-sm custom-scrollbar"
+      >
         {messages.map((msg, index) => (
           <div key={index} className="flex items-start">
-            <span className={`font-bold mr-2 player-color-${msg.senderColor || "gray"}`}>{msg.senderName}:</span>
+            <span
+              className={`font-bold mr-2 player-color-${msg.senderColor || "gray"}`}
+            >
+              {msg.senderName}:
+            </span>
             <p className="flex-1 text-stone-300 break-words">{msg.message}</p>
             {msg.timestamp && (
               <span className="ml-auto text-xs text-stone-500">
-                {new Date(msg.timestamp.seconds * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                {new Date(msg.timestamp.seconds * 1000).toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
               </span>
             )}
           </div>
         ))}
         <div ref={messagesEndRef} />
       </div>
-      <form onSubmit={handleSend} className="p-4 border-t border-stone-600 flex gap-2">
+      <form
+        onSubmit={handleSend}
+        className="p-4 border-t border-stone-600 flex gap-2"
+      >
         <input
           type="text"
           value={inputMessage}
           onChange={(e) => setInputMessage(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              handleSend(e);
+            }
+          }}
           placeholder="Type your message..."
           className="flex-1 px-3 py-2 bg-stone-700 border border-stone-600 rounded-md text-stone-200 placeholder-stone-400 focus:outline-none focus:border-amber-500"
         />
@@ -69,5 +92,5 @@ export function WorldChat({ messages, onSendMessage, playerName, playerColor }: 
         </button>
       </form>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- keep world chat scrolled to bottom on mount and when new messages arrive
- allow pressing Enter to send messages instantly

## Testing
- `pnpm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_683fca10b0d0832f8517e23460273a69