### PR TITLE
Add wishlist section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Recent additions to **Arrakis Spice Empire** include:
 - Expanded equipment pool with new items ranging from common to mythic rarity.
 - Introduced mythic rarity gear with drop rates over 200x rarer than legendary.
 
+## Wishlist
+
+Have an idea for a new feature? Open the **Wishlist** tab in game and submit a simple gameplay request.
+
 ## How It Works
 
 1. Create and modify your project using [v0.dev](https://v0.dev)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,6 +28,7 @@ import { AbilitySelectionModal } from "@/components/modals/ability-selection-mod
 import { TradePanel } from "@/components/trade-panel"
 import { TradingModal } from "@/components/modals/trading-modal"
 import { UpdatesTab } from "@/components/updates-tab"
+import { WishlistTab } from "@/components/wishlist-tab"
 import { BountyBoard } from "@/components/bounty-board"
 import { Slider } from "@/components/ui/slider"
 import { PauseModal } from "@/components/modals/pause-modal"
@@ -3036,6 +3037,7 @@ export default function ArrakisGamePage() {
             </div>
           )}
           {gameState.currentTab === "updates" && <UpdatesTab />}
+          {gameState.currentTab === "wishlist" && <WishlistTab />}
         </div>
       </main>
 

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -11,6 +11,7 @@ const tabs = [
   { id: "empire", label: "🏗️ Empire" },
   { id: "multiplayer", label: "🌍 Multiplayer" },
   { id: "updates", label: "📰 Updates" }, // New tab
+  { id: "wishlist", label: "🌠 Wishlist" },
 ]
 
 export function Navigation({ currentTab, onTabChange }: NavigationProps) {

--- a/components/wishlist-tab.tsx
+++ b/components/wishlist-tab.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useState } from "react"
+
+export function WishlistTab() {
+  const [wishlistItems, setWishlistItems] = useState<string[]>([])
+  const [input, setInput] = useState("")
+
+  const handleAdd = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = input.trim()
+    if (!trimmed) return
+    setWishlistItems((prev) => [...prev, trimmed])
+    setInput("")
+  }
+
+  return (
+    <div className="flex-1 p-6 overflow-y-auto">
+      <h2 className="text-3xl font-orbitron text-amber-400 mb-6">🌠 Wishlist</h2>
+      <p className="text-stone-300 mb-4 text-sm">
+        Share ideas for new gameplay features you'd like to see added.
+      </p>
+      <form onSubmit={handleAdd} className="flex gap-2 mb-6">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Add your wish..."
+          className="flex-1 px-3 py-2 bg-stone-700 border border-stone-600 rounded-md text-stone-200 placeholder-stone-400 focus:outline-none focus:border-amber-500"
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-md disabled:bg-stone-500"
+          disabled={!input.trim()}
+        >
+          Add
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {wishlistItems.length === 0 && (
+          <li className="text-stone-400 text-sm">No requests yet.</li>
+        )}
+        {wishlistItems.map((wish, idx) => (
+          <li
+            key={idx}
+            className="bg-stone-800 p-3 rounded border border-stone-600 text-stone-300"
+          >
+            {wish}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `WishlistTab` component
- link wishlist tab in navigation
- render wishlist tab when selected
- document new feature in README

## Testing
- `pnpm install`
- `pnpm lint` *(fails: asked for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683fca3680a0832f97593ab7a481ead9