### PR TITLE
Add mythic and legendary drop announcements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -852,8 +852,9 @@ export default function ArrakisGamePage() {
                 itemData.rarity === "mythic" ? "mythic" : itemData.rarity === "legendary" ? "legendary" : "success"
               addNotification(`You found a ${itemData.icon} ${itemData.name}!`, noticeType as any)
               addNotification(`You found a ${itemData.icon} ${itemData.name}!`, "success")
-              if (itemData.rarity === "epic" || itemData.rarity === "legendary") {
-                addWorldChatMessage(`${newPlayer.name} found an ${itemData.rarity} ${itemData.name}!`)
+              if (itemData.rarity === "legendary" || itemData.rarity === "mythic") {
+                const rarityLabel = itemData.rarity.toUpperCase()
+                addWorldChatMessage(`🎉 ${newPlayer.name} discovered a ${rarityLabel} ${itemData.name}! 🎉`)
               }
             } else {
               addNotification(`Inventory full! Could not pick up ${itemData.name}.`, "warning")


### PR DESCRIPTION
## Summary
- announce legendary and mythic drops in world chat with flashy message

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_683fcacc24bc832f86a6e8dfc8cfc0c6