### PR TITLE
Fix React imports for Next.js classic runtime

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type React from "react"
+import React from "react"
 import type { Metadata } from "next"
 import { Inter, Orbitron } from "next/font/google"
 import "./globals.css"

--- a/components/actions-panel.tsx
+++ b/components/actions-panel.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Player, Resources } from "@/types/game"
 import { CONFIG } from "@/lib/constants" // Import CONFIG for costs
 

--- a/components/bounty-board.tsx
+++ b/components/bounty-board.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { GameState, Resources } from "@/types/game"
 import { CONFIG } from "@/lib/constants"
 

--- a/components/character-tab.tsx
+++ b/components/character-tab.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Player, Equipment, Item, Ability, Resources } from "@/types/game"
 import { CONFIG, CRAFTING_RECIPES } from "@/lib/constants" // For MAX_INVENTORY and crafting costs
 import {

--- a/components/empire-tab.tsx
+++ b/components/empire-tab.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Player, Resources, Investment } from "@/types/game"
 import { CONFIG } from "@/lib/constants"
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Player } from "@/types/game"
 import { STATIC_DATA } from "@/lib/game-data"
 import { signOut } from "firebase/auth"

--- a/components/houses-panel.tsx
+++ b/components/houses-panel.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { STATIC_DATA } from "@/lib/game-data"
 import type { GameState, TerritoryDetails, Player } from "@/types/game"
 

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { RankedPlayer } from "@/types/game"
 import { STATIC_DATA } from "@/lib/game-data"
 

--- a/components/loading-screen.tsx
+++ b/components/loading-screen.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 interface LoadingScreenProps {
   isVisible: boolean
 }

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import type React from "react"
-
-import { useState } from "react"
+import React, { useState } from "react"
 import { auth } from "@/lib/firebase"
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from "firebase/auth"
 

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type React from "react"
+import React from "react"
 
 import type { GameState, Player } from "@/types/game"
 import { CONFIG, HOUSE_COLORS } from "@/lib/constants"

--- a/components/modals/ability-selection-modal.tsx
+++ b/components/modals/ability-selection-modal.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Ability } from "@/types/game"
 
 interface AbilitySelectionModalProps {

--- a/components/modals/house-selection-modal.tsx
+++ b/components/modals/house-selection-modal.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { STATIC_DATA } from "@/lib/game-data"
 
 interface HouseSelectionModalProps {

--- a/components/modals/houses-modal.tsx
+++ b/components/modals/houses-modal.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { STATIC_DATA } from "@/lib/game-data"
 import type { GameState } from "@/types/game"
 

--- a/components/modals/name-selection-modal.tsx
+++ b/components/modals/name-selection-modal.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import type React from "react"
-import { useState, useCallback } from "react" // Import useCallback
+import React, { useState, useCallback } from "react" // Import useCallback
 import { Button } from "@/components/ui/button"
 
 interface NameSelectionModalProps {

--- a/components/modals/pause-modal.tsx
+++ b/components/modals/pause-modal.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 interface PauseModalProps {
   isOpen: boolean
   onResume: () => void

--- a/components/modals/prestige-modal.tsx
+++ b/components/modals/prestige-modal.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 interface PrestigeModalProps {
   isOpen: boolean
   onClose: () => void

--- a/components/modals/territory-modal.tsx
+++ b/components/modals/territory-modal.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { TerritoryDetails, Resources } from "@/types/game"
 
 interface TerritoryModalProps {

--- a/components/modals/world-events-modal.tsx
+++ b/components/modals/world-events-modal.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { WorldEvent } from "@/types/game"
 
 interface WorldEventsModalProps {

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 interface NavigationProps {
   currentTab: string
   onTabChange: (tab: string) => void

--- a/components/player-stats-panel.tsx
+++ b/components/player-stats-panel.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Player } from "@/types/game"
 
 interface PlayerStatsPanelProps {

--- a/components/quest-panel.tsx
+++ b/components/quest-panel.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Quest } from "@/types/game"
 
 interface QuestPanelProps {

--- a/components/sandworm-warning.tsx
+++ b/components/sandworm-warning.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 interface SandwormWarningProps {
   timeLeft: number
 }

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Player, Resources } from "@/types/game"
 
 interface SidebarProps {

--- a/components/territory-chart.tsx
+++ b/components/territory-chart.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from "recharts"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"

--- a/components/trade-panel.tsx
+++ b/components/trade-panel.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { Player, Resources } from "@/types/game"
 
 interface TradePanelProps {

--- a/components/ui/resizable.tsx
+++ b/components/ui/resizable.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { GripVertical } from "lucide-react"
 import * as ResizablePrimitive from "react-resizable-panels"
 

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { cn } from "@/lib/utils"
 
 function Skeleton({

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { useTheme } from "next-themes"
 import { Toaster as Sonner } from "sonner"
 

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import { useToast } from "@/hooks/use-toast"
 import {
   Toast,

--- a/components/updates-tab.tsx
+++ b/components/updates-tab.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 export function UpdatesTab() {
   const updates = [
     {

--- a/components/world-chat.tsx
+++ b/components/world-chat.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import type { ChatMessage } from "@/types/game"
-import type React from "react"
-import { useState, useRef, useEffect } from "react"
+import React, { useState, useRef, useEffect } from "react"
 
 interface WorldChatProps {
   messages: ChatMessage[]

--- a/components/world-events-panel.tsx
+++ b/components/world-events-panel.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import React from "react"
 import type { WorldEvent } from "@/types/game"
 
 interface WorldEventsPanelProps {


### PR DESCRIPTION
## Summary
- add default React imports to many JSX files

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_683fcaee562c832fb5209576775fceb8