### PR TITLE
Enable prestige at level 10

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2761,8 +2761,8 @@ export default function ArrakisGamePage() {
 
   const handleOpenPrestigeModal = useCallback(() => {
     setGameState((prev) => {
-      if (prev.player.level < 20) {
-        addNotification("Reach level 20 to Prestige!", "warning")
+      if (prev.player.level < 10) {
+        addNotification("Reach level 10 to Prestige!", "warning")
         return prev
       }
       return { ...prev, isPrestigeModalOpen: true }

--- a/components/character-tab.tsx
+++ b/components/character-tab.tsx
@@ -240,17 +240,17 @@ export function CharacterTab({
               Reach new heights of power by prestiging! Reset your progress for a significant bonus to future gains.
             </p>
             <button
-              onClick={player.level >= 20 ? onOpenPrestigeModal : undefined}
-              disabled={player.level < 20}
+              onClick={player.level >= 10 ? onOpenPrestigeModal : undefined}
+              disabled={player.level < 10}
               className={`w-full py-2 px-4 font-semibold rounded-md transition duration-150 ease-in-out ${
-                player.level >= 20
+                player.level >= 10
                   ? "bg-purple-600 hover:bg-purple-700 text-white"
                   : "bg-stone-500 text-white cursor-not-allowed"
               }`}
             >
-              {player.level >= 20
+              {player.level >= 10
                 ? `Ascend to Prestige ${player.prestigeLevel + 1}`
-                : "Reach Level 20 to Prestige"}
+                : "Reach Level 10 to Prestige"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow players to open the prestige modal once they reach level 10
- update prestige button text and disabled state

## Testing
- `npx next lint` *(fails: requires interactive setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683fd4ec1438832fb46bac211f65f617