### PR TITLE
Improve mobile map interaction

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,7 @@ import { BountyBoard } from "@/components/bounty-board"
 import { Slider } from "@/components/ui/slider"
 import { PauseModal } from "@/components/modals/pause-modal"
 import { SandwormWarning } from "@/components/sandworm-warning"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 import type {
   GameState,
@@ -456,6 +457,7 @@ export default function ArrakisGamePage() {
   const [availableAbilitiesForSelection, setAvailableAbilitiesForSelection] = useState<Ability[]>([])
   const [zoom, setZoom] = useState(1.2)
   const [user, setUser] = useState(() => auth.currentUser)
+  const isMobile = useIsMobile()
 
   // All hooks must be declared unconditionally at the top level
   useEffect(() => {
@@ -2943,8 +2945,8 @@ export default function ArrakisGamePage() {
                   </div>
                 </div>
                 <div className="text-sm text-stone-400 mb-4 p-3 bg-stone-800 rounded-lg border border-stone-600 text-center">
-                  <span className="font-semibold text-amber-400">Controls:</span> WASD/Arrow Keys to move • Click cells
-                  to interact/purchase territory.
+                  <span className="font-semibold text-amber-400">Controls:</span>
+                  {isMobile ? " Tap a nearby tile to move • Tap cells to interact or purchase territory." : " WASD/Arrow Keys to move • Click cells to interact/purchase territory."}
                 </div>
                 <div className="flex items-center gap-3 mb-4">
                   <span className="text-stone-300 text-sm">Zoom:</span>

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import React from "react"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 import type { GameState, Player } from "@/types/game"
 import { CONFIG, HOUSE_COLORS } from "@/lib/constants"
@@ -27,8 +28,22 @@ export function MapGrid({
   onZoomChange,
   trackingTarget = null,
 }: MapGridProps) {
+  const isMobile = useIsMobile()
+  const gridRef = React.useRef<HTMLDivElement>(null)
+  const playerCellRef = React.useRef<HTMLDivElement>(null)
   const { x: playerX, y: playerY } = player.position
   const radius = CONFIG.VIEW_RADIUS
+
+  React.useEffect(() => {
+    if (!isMobile) return
+    const grid = gridRef.current
+    const playerCell = playerCellRef.current
+    if (grid && playerCell) {
+      const left = playerCell.offsetLeft - grid.clientWidth / 2 + playerCell.clientWidth / 2
+      const top = playerCell.offsetTop - grid.clientHeight / 2 + playerCell.clientHeight / 2
+      grid.scrollTo({ left, top })
+    }
+  }, [playerX, playerY, zoom, isMobile])
 
   const arrow = React.useMemo(() => {
     if (!trackingTarget) return ""
@@ -155,6 +170,7 @@ export function MapGrid({
       cells.push(
         <div
           key={key}
+          ref={x === playerX && y === playerY ? playerCellRef : undefined}
           className={cellClass}
           title={cellTitle}
           onClick={() => onCellClick(x, y)}
@@ -187,7 +203,7 @@ export function MapGrid({
   return (
     <div className="relative">
       {arrow && <div className="tracking-arrow">{arrow}</div>}
-      <div className="map-grid mx-auto overflow-x-auto" style={gridStyle}>
+      <div ref={gridRef} className="map-grid mx-auto overflow-x-auto" style={gridStyle}>
         {cells}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- auto-center the player's position on mobile
- show mobile-specific movement instructions

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684060d513ac832fa1083fa821883880