### PR TITLE
Random respawn after death

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -983,9 +983,9 @@ export default function ArrakisGamePage() {
           }
         }
       } else if (result === "lose") {
-        newPlayer.position = { ...newPlayer.basePosition }
+        newPlayer.position = getRandomMapCoords()
         newPlayer.health = Math.floor(newPlayer.maxHealth / 2)
-        addNotification("You respawned at your base.", "info")
+        addNotification("You respawned in a random location.", "info")
         if (currentFullGameState.capturingTerritoryId) {
           const terrKey = currentFullGameState.capturingTerritoryId
           const terr = newMap.territories[terrKey]
@@ -1934,9 +1934,10 @@ export default function ArrakisGamePage() {
               newPlayer.territories = newPlayer.territories.filter((t) => t.id !== terr.id)
             }
           }
-          newPlayer.position = { ...newPlayer.basePosition }
+          newPlayer.position = getRandomMapCoords()
           newPlayer.health = Math.floor(newPlayer.maxHealth / 2)
           newNotifications.push({ id: (now + 1).toString(), message: "A sandworm devours you!", type: "legendary" })
+          newNotifications.push({ id: (now + 2).toString(), message: "You respawned in a random location.", type: "info" })
           sandwormAttackTime = null
         }
 


### PR DESCRIPTION
## Summary
- respawn the player in a random location when defeated in combat
- respawn the player in a random location when a sandworm devours them

## Testing
- `pnpm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684060f9b628832fa02e4970b4d38dbe