### PR TITLE
Add button to cancel sandworm idle timer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2882,6 +2882,14 @@ export default function ArrakisGamePage() {
     [addNotification],
   )
 
+  const handleSandwormContinue = useCallback(() => {
+    setGameState((prev) => ({
+      ...prev,
+      sandwormAttackTime: null,
+      player: { ...prev.player, lastActive: Date.now() },
+    }))
+  }, [])
+
   // Conditional rendering starts here, after all hooks are declared
   if (!user) return <LoginForm />
   if (isLoading) return <LoadingScreen isVisible={true} />
@@ -3162,7 +3170,10 @@ export default function ArrakisGamePage() {
         onRemoveOffer={handleRemoveTradeOffer}
       />
       <PauseModal isOpen={gameState.isPaused} onResume={() => setGameState((prev) => ({ ...prev, isPaused: false }))} />
-      <SandwormWarning timeLeft={gameState.sandwormAttackTime ? gameState.sandwormAttackTime - Date.now() : 0} />
+      <SandwormWarning
+        timeLeft={gameState.sandwormAttackTime ? gameState.sandwormAttackTime - Date.now() : 0}
+        onContinue={handleSandwormContinue}
+      />
     </div>
   )
 }

--- a/components/sandworm-warning.tsx
+++ b/components/sandworm-warning.tsx
@@ -3,15 +3,29 @@
 import React from "react"
 interface SandwormWarningProps {
   timeLeft: number
+  onContinue: () => void
 }
 
-export function SandwormWarning({ timeLeft }: SandwormWarningProps) {
+export function SandwormWarning({ timeLeft, onContinue }: SandwormWarningProps) {
   if (timeLeft <= 0) return null
   return (
-    <div className="fixed inset-0 bg-stone-950/80 text-amber-400 flex items-center justify-center z-[10000]">
-      <div className="text-center space-y-4">
+    <div
+      className="fixed inset-0 bg-stone-950/80 text-amber-400 flex items-center justify-center z-[10000]"
+      onClick={onContinue}
+      onTouchStart={onContinue}
+    >
+      <div className="text-center space-y-4 px-4">
         <div className="text-4xl font-orbitron">🐛 Wormsign!</div>
         <div className="text-xl">Move or be eaten in {Math.ceil(timeLeft / 1000)}s</div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onContinue()
+          }}
+          className="action-button w-full max-w-xs mx-auto"
+        >
+          Continue
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- allow continuing the game when the sandworm idle timer appears
- expose a handler to dismiss the warning and reset idle timer

## Testing
- `pnpm install`
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840614147a0832fa6560ee86bd7688c