### PR TITLE
Add online player count

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2902,7 +2902,10 @@ export default function ArrakisGamePage() {
       <Header
         player={gameState.player}
         isPaused={gameState.isPaused}
-        onTogglePause={() => setGameState((prev) => ({ ...prev, isPaused: !prev.isPaused }))}
+        onTogglePause={() =>
+          setGameState((prev) => ({ ...prev, isPaused: !prev.isPaused }))
+        }
+        onlinePlayerCount={Object.keys(gameState.onlinePlayers).length + 1}
       />
       <Navigation currentTab={gameState.currentTab} onTabChange={handleTabChange} />
       <NotificationArea

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -10,10 +10,11 @@ interface HeaderProps {
   player: Player
   isPaused: boolean
   onTogglePause: () => void
+  onlinePlayerCount: number
   // Removed onTradeClick, onOpenHousesModal, onOpenWorldEventsModal
 }
 
-export function Header({ player, isPaused, onTogglePause }: HeaderProps) {
+export function Header({ player, isPaused, onTogglePause, onlinePlayerCount }: HeaderProps) {
   const house = player.house ? STATIC_DATA.HOUSES[player.house] : null
 
   return (
@@ -37,6 +38,10 @@ export function Header({ player, isPaused, onTogglePause }: HeaderProps) {
           <div className="text-sm">
             <span className="text-stone-400">Prestige:</span>
             <span className="font-bold text-purple-400 prestige-glow ml-1">{player.prestigeLevel}</span>
+          </div>
+          <div className="text-sm">
+            <span className="text-stone-400">Online:</span>
+            <span className="font-bold text-green-400 ml-1">{onlinePlayerCount}</span>
           </div>
           <button
             onClick={onTogglePause}


### PR DESCRIPTION
## Summary
- show online player count in the header next to Prestige level
- pass count from game state when rendering `Header`

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684061dc50d0832fa52055b3e5433a25