### PR TITLE
Fix for client-side exception when opening multiplayer

### DIFF
--- a/components/ui/use-mobile.tsx
+++ b/components/ui/use-mobile.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768

--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768


### PR DESCRIPTION
## Summary
- ensure `useIsMobile` hook runs on client side by adding `'use client'`

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6840676bfd00832f8e7282b5f899ada5