### PR TITLE
Fix mobile tap movement

### DIFF
--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -214,6 +214,7 @@ export function MapGrid({
           className={cellClass}
           title={cellTitle}
           onClick={() => onCellClick(x, y)}
+          onTouchStart={() => onCellClick(x, y)}
           style={
             territory && territory.ownerId
               ? {


### PR DESCRIPTION
## Summary
- allow tapping grid cells to move on mobile

## Testing
- `pnpm install --frozen-lockfile --ignore-scripts`
- `npx next lint` *(fails: prompts for eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_684074aa0b5c832f9b280cf7e878525e