### PR TITLE
Improve mobile map layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -104,16 +104,6 @@ body {
   color: #fed7aa; /* Default text color for desert cells */
 }
 
-@media (max-width: 640px) {
-  .map-grid {
-    grid-template-columns: repeat(15, 20px);
-  }
-  .map-cell {
-    width: 20px;
-    height: 20px;
-    font-size: 0.75rem;
-  }
-}
 
 .map-cell:hover {
   transform: scale(1.1);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -460,6 +460,12 @@ export default function ArrakisGamePage() {
   const [seekerLaunchVisualTime, setSeekerLaunchVisualTime] = useState(0)
   const isMobile = useIsMobile()
 
+  useEffect(() => {
+    if (isMobile) {
+      setZoom(0.6)
+    }
+  }, [isMobile])
+
   // All hooks must be declared unconditionally at the top level
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, (u) => setUser(u))


### PR DESCRIPTION
## Summary
- prevent mobile CSS override that caused extremely tall grid
- adjust zoom on mobile devices to scale the grid

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684076778400832fae47d00bb6f5deb7