### PR TITLE
Add collectible water caches

### DIFF
--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -199,6 +199,16 @@ export function MapGrid({
         hasBackground = true
       }
 
+      const resource = mapData.resources[key]
+      if (resource && cellContent === "") {
+        if (resource.type === 'water_cache') {
+          cellClass += ' map-cell-resource-water'
+          cellContent = resource.icon || '💧'
+          cellTitle = `Water Cache`
+          hasBackground = true
+        }
+      }
+
       if (isAdjacent) {
         cellClass += " map-cell-movable"
       }

--- a/types/game.ts
+++ b/types/game.ts
@@ -38,6 +38,8 @@ export interface Player {
   isDefending: boolean
   xpBuffMultiplier?: number
   xpBuffExpires?: number | null
+  /** Timestamp until which the player can move two squares at a time */
+  speedBoostExpires?: number | null
   // NEW: For AI resource tracking, we will add 'resources' directly to the AI player object in GameState.onlinePlayers.
   // No change to Player type itself is strictly needed if AIs in onlinePlayers are Partial<Player> & {resources: Resources}
   equipment?: Equipment // Added for AI ranking


### PR DESCRIPTION
## Summary
- spawn rare water caches on the map
- picking up a water cache grants a 5s speed boost and restores water
- show water caches in the map grid
- allow moving up to two tiles while boosted
- track boost expiration in player state

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6843ff66d260832f95de540cfb99ff20