### PR TITLE
Add mobile movement controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -784,3 +784,24 @@ body {
     font-size: 0.875rem;
   }
 }
+.mobile-controls {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  width: 8rem;
+}
+.mobile-arrow {
+  @apply bg-stone-700 text-amber-300 rounded-lg flex items-center justify-center;
+  @apply active:bg-stone-600;
+}
+.mobile-arrow svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+@media (min-width: 768px) {
+  .mobile-controls {
+    display: none;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { Header } from "@/components/header"
 import { Navigation } from "@/components/navigation"
 import { Sidebar } from "@/components/sidebar"
 import { MapGrid } from "@/components/map-grid"
+import { MobileMovementControls } from "@/components/mobile-movement-controls"
 import { CharacterTab } from "@/components/character-tab"
 import { EmpireTab } from "@/components/empire-tab"
 import { TerritoryModal } from "@/components/modals/territory-modal"
@@ -2994,6 +2995,16 @@ export default function ArrakisGamePage() {
                   }
                   seekerLaunchTime={seekerLaunchVisualTime}
                 />
+                {isMobile && (
+                  <MobileMovementControls
+                    onMove={(dx, dy) => {
+                      const { x, y } = gameState.player.position
+                      const newX = Math.max(0, Math.min(CONFIG.MAP_SIZE - 1, x + dx))
+                      const newY = Math.max(0, Math.min(CONFIG.MAP_SIZE - 1, y + dy))
+                      attemptPlayerAction(newX, newY)
+                    }}
+                  />
+                )}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
                   <Leaderboard topPlayers={gameState.leaderboard} />
                   <HousesPanel

--- a/components/map-grid.tsx
+++ b/components/map-grid.tsx
@@ -228,7 +228,6 @@ export function MapGrid({
               }
             }
           }}
-          onTouchStart={() => onCellClick(x, y)}
           style={
             territory && territory.ownerId
               ? {

--- a/components/mobile-movement-controls.tsx
+++ b/components/mobile-movement-controls.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import React from "react"
+import { ArrowUp, ArrowDown, ArrowLeft, ArrowRight } from "lucide-react"
+
+interface MobileMovementControlsProps {
+  onMove: (dx: number, dy: number) => void
+}
+
+export function MobileMovementControls({ onMove }: MobileMovementControlsProps) {
+  return (
+    <div className="mobile-controls grid grid-cols-3 gap-2">
+      <button
+        aria-label="Move up"
+        className="mobile-arrow col-start-2 row-start-1"
+        onClick={() => onMove(0, -1)}
+      >
+        <ArrowUp className="w-5 h-5" />
+      </button>
+      <button
+        aria-label="Move left"
+        className="mobile-arrow col-start-1 row-start-2"
+        onClick={() => onMove(-1, 0)}
+      >
+        <ArrowLeft className="w-5 h-5" />
+      </button>
+      <button
+        aria-label="Move right"
+        className="mobile-arrow col-start-3 row-start-2"
+        onClick={() => onMove(1, 0)}
+      >
+        <ArrowRight className="w-5 h-5" />
+      </button>
+      <button
+        aria-label="Move down"
+        className="mobile-arrow col-start-2 row-start-3"
+        onClick={() => onMove(0, 1)}
+      >
+        <ArrowDown className="w-5 h-5" />
+      </button>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- allow touch-friendly movement by adding MobileMovementControls
- hide controls on desktop via CSS
- remove premature touch handler from map grid

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684400385350832fa02946d0dc9a4256