### PR TITLE
Add heat meter system

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -291,6 +291,7 @@ const getInitialPlayerState = (id: string | null, prestigeLevel = 0): Player => 
     xpBuffMultiplier: 1,
     xpBuffExpires: null,
     speedBoostExpires: null,
+    heat: 0,
   }
 }
 
@@ -1551,6 +1552,8 @@ export default function ArrakisGamePage() {
           const healthRegenAmount = Math.floor(newPlayer.maxHealth * (newPlayer.activeAbility.effectValue / 100))
           newPlayer.health = Math.min(newPlayer.maxHealth, newPlayer.health + healthRegenAmount)
         }
+        const heatDecayMultiplier = isInBaseArea(newPlayer, newPlayer.position.x, newPlayer.position.y) ? 2 : 1
+        newPlayer.heat = Math.max(0, newPlayer.heat - CONFIG.HEAT_DECAY_PER_TICK * heatDecayMultiplier)
 
         let territorySpiceIncomeBoost = 1.0
         if (newWorldEvents.some((event) => event.effect === "spice_boost" && event.endTime && event.endTime > now)) {
@@ -2303,6 +2306,10 @@ export default function ArrakisGamePage() {
           // Sandwalk reduces water cost
           waterCost = Math.max(0.1, waterCost - waterCost * (player.activeAbility.effectValue / 100)) // Ensure it costs at least a bit
         }
+        if (player.house === "fremen") {
+          waterCost *= 0.4
+        }
+        waterCost *= 1 + player.heat * CONFIG.HEAT_WATER_MULTIPLIER
         const distance = Math.max(Math.abs(dx), Math.abs(dy))
         waterCost = Math.round(waterCost * distance * 10) / 10 // Round to one decimal
 
@@ -2319,6 +2326,7 @@ export default function ArrakisGamePage() {
         if (isMoving) {
           newPlayer.position = { x: targetX, y: targetY }
           newResources.water -= waterCost
+          newPlayer.heat = Math.min(CONFIG.MAX_HEAT, newPlayer.heat + CONFIG.HEAT_INCREASE_PER_MOVE * distance)
           newPlayer.lastActive = Date.now()
           sandwormAttackTime = null
         }
@@ -2436,6 +2444,7 @@ export default function ArrakisGamePage() {
         const resourceOnCell = map.resources[key]
         if (resourceOnCell && resourceOnCell.type === 'water_cache') {
           newResources.water += resourceOnCell.amount
+          newPlayer.heat = Math.max(0, newPlayer.heat - CONFIG.MAX_HEAT * 0.5)
           newPlayer.speedBoostExpires = Date.now() + 5000
           delete newMap.resources[key]
           addNotification(`Collected water cache! Speed boosted for 5s.`, 'success')
@@ -2869,6 +2878,7 @@ export default function ArrakisGamePage() {
       if (newPlayer.energy >= CONFIG.COLLECT_WATER_ENERGY_COST) {
         newPlayer.energy -= CONFIG.COLLECT_WATER_ENERGY_COST
         newResources.water += CONFIG.COLLECT_WATER_YIELD
+        newPlayer.heat = Math.max(0, newPlayer.heat - CONFIG.HEAT_DECAY_PER_TICK * 5)
         applyXpGain(newPlayer, CONFIG.XP_GAIN_GATHER)
         addNotification(`Collected ${CONFIG.COLLECT_WATER_YIELD} Water!`, "success")
       } else {

--- a/components/player-stats-panel.tsx
+++ b/components/player-stats-panel.tsx
@@ -2,6 +2,7 @@
 
 import React from "react"
 import type { Player } from "@/types/game"
+import { CONFIG } from "@/lib/constants"
 
 interface PlayerStatsPanelProps {
   player: Player
@@ -11,6 +12,7 @@ export function PlayerStatsPanel({ player }: PlayerStatsPanelProps) {
   const playerHealthPercent = (player.health / player.maxHealth) * 100
   const playerEnergyPercent = (player.energy / player.maxEnergy) * 100
   const playerXPPercent = (player.experience / player.experienceToNext) * 100
+  const playerHeatPercent = (player.heat / CONFIG.MAX_HEAT) * 100
 
   return (
     <div className="bg-stone-700 p-4 rounded-lg border border-blue-500">
@@ -39,6 +41,17 @@ export function PlayerStatsPanel({ player }: PlayerStatsPanelProps) {
           </div>
           <div className="progress-bar-bg rounded h-3">
             <div className="bg-blue-500 h-full rounded" style={{ width: `${playerEnergyPercent}%` }}></div>
+          </div>
+        </div>
+        <div className="p-2 bg-stone-600 rounded">
+          <div className="flex justify-between mb-1">
+            <span>Heat:</span>
+            <span className="font-mono">
+              {player.heat}/{CONFIG.MAX_HEAT}
+            </span>
+          </div>
+          <div className="progress-bar-bg rounded h-3">
+            <div className="bg-orange-500 h-full rounded" style={{ width: `${playerHeatPercent}%` }}></div>
           </div>
         </div>
         <div className="p-2 bg-stone-600 rounded">

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -57,6 +57,10 @@ export const CONFIG = {
   XP_GAIN_BUILD_BASE: 10,
   XP_GAIN_CRAFT: 5,
   BASE_RADIUS: 2, // New constant for base area
+  MAX_HEAT: 100,
+  HEAT_INCREASE_PER_MOVE: 5,
+  HEAT_DECAY_PER_TICK: 2,
+  HEAT_WATER_MULTIPLIER: 0.01,
 }
 
 export const PLAYER_COLORS = ["red", "blue", "green", "purple", "orange", "pink", "yellow", "cyan"]

--- a/types/game.ts
+++ b/types/game.ts
@@ -40,6 +40,7 @@ export interface Player {
   xpBuffExpires?: number | null
   /** Timestamp until which the player can move two squares at a time */
   speedBoostExpires?: number | null
+  heat: number
   // NEW: For AI resource tracking, we will add 'resources' directly to the AI player object in GameState.onlinePlayers.
   // No change to Player type itself is strictly needed if AIs in onlinePlayers are Partial<Player> & {resources: Resources}
   equipment?: Equipment // Added for AI ranking


### PR DESCRIPTION
## Summary
- introduce heat-related constants
- add `heat` property to `Player`
- show heat meter in the stats panel
- drain water faster based on heat and Fremen house bonus
- heat increases while moving and cools at base or water caches

## Testing
- `pnpm lint` *(fails: interactive prompt requires Next.js plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684838d2cb30832f8c9e00d03b4b86b8